### PR TITLE
Inventory proper map rendering by role

### DIFF
--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -34,7 +34,7 @@
     // Add React app as iframe if iframe doesn't already exist
     if ($(myView + " #mapIFrame").length === 0) {
       $(
-        '<iframe src="https://5d2115b19ceaed0007c6ae7d--atd-geo-knack-ui.netlify.com/" frameborder="0" scrolling="yes" id="mapIFrame" \
+        '<iframe src="https://atd-geo-knack-ui.netlify.com/" frameborder="0" scrolling="yes" id="mapIFrame" \
     style="width: 100%;height: 523px;"></iframe>'
       ).appendTo($viewSelector);
     }

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -58,7 +58,6 @@
     });
 
     // Location Details Page Maps
-
     function locationDetailsMapMessage(viewId) {
       var locationViewIFrame = $("#" + viewId + " #mapIFrame")[0].contentWindow;
       var urlArray = window.location.href.split("/");
@@ -89,11 +88,12 @@
       locationDetailsMapMessage("view_2733");
     });
 
-    // Work Orders Details Page - Editable
-    $("#view_2573 #mapIFrame").on("load", function() {
+    // Work Orders Details Page Maps
+    function workOrdersDetialsMapMessage(viewId) {
       var urlArray = window.location.href.split("/");
       var recordId = urlArray[urlArray.length - 2];
-      var workOrderDetailsIFrame = $("#view_2573 #mapIFrame")[0].contentWindow;
+      var workOrderDetailsIFrame = $("#" + viewId + " #mapIFrame")[0]
+        .contentWindow;
 
       var markerMessage = {
         message: "SIGNS_API_REQUEST",
@@ -105,6 +105,14 @@
       };
 
       sendMessageToApp(markerMessage, workOrderDetailsIFrame);
+    }
+    // Work Order Details Page - Editable
+    $("#view_2573 #mapIFrame").on("load", function() {
+      workOrdersDetialsMapMessage("view_2573");
+    });
+    // Work Order Details Page - Viewable
+    $("#view_2619 #mapIFrame").on("load", function() {
+      workOrdersDetialsMapMessage("view_2619");
     });
 
     // Edit Location Page

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -57,8 +57,10 @@
       }
     });
 
-    $("#view_2609 #mapIFrame").on("load", function() {
-      var locationViewIFrame = $("#view_2609 #mapIFrame")[0].contentWindow;
+    // Location Details Page Maps
+
+    function locationDetailsMapMessage(viewId) {
+      var locationViewIFrame = $("#" + viewId + " #mapIFrame")[0].contentWindow;
       var urlArray = window.location.href.split("/");
       var recordId = urlArray[urlArray.length - 2];
       var workOrderId = urlArray[urlArray.length - 4];
@@ -76,9 +78,19 @@
       };
 
       sendMessageToApp(markerMessage, locationViewIFrame);
+    }
+    // Location Details Page - Editable
+    $("#view_2609 #mapIFrame").on("load", function() {
+      locationDetailsMapMessage("view_2609");
     });
 
-    $("#mapIFrame").on("load", function() {
+    // Location Details Page - Viewer
+    $("#view_2733 #mapIFrame").on("load", function() {
+      locationDetailsMapMessage("view_2733");
+    });
+
+    // Work Orders Details Page - Editable
+    $("#view_2573 #mapIFrame").on("load", function() {
       var urlArray = window.location.href.split("/");
       var recordId = urlArray[urlArray.length - 2];
       var workOrderDetailsIFrame = $("#view_2573 #mapIFrame")[0].contentWindow;
@@ -95,6 +107,7 @@
       sendMessageToApp(markerMessage, workOrderDetailsIFrame);
     });
 
+    // Edit Location Page
     $("#view_2682 #mapIFrame").on("load", function() {
       // Use crumbtrail to get Location record ID
       var crumbtrailArray = $(".kn-crumbtrail")

--- a/knack/index.js
+++ b/knack/index.js
@@ -354,7 +354,7 @@ $(document).on("knack-view-render.view_2465", function(event, page) {
 
 function loadIframeMapMessenger(viewId) {
   var url =
-    "https://dnb4pix4gcpf6.cloudfront.net/atd-knack-signs-markings/user_testing/iframeMapMessenger.js";
+    "https://dnb4pix4gcpf6.cloudfront.net/atd-knack-signs-markings/88_update_view_ids/iframeMapMessenger.js";
   $.getScript(url, function(data, textStatus, jqxhr) {
     console.log(data); // Data returned
     console.log(textStatus); // Success

--- a/knack/index.js
+++ b/knack/index.js
@@ -365,11 +365,13 @@ function loadIframeMapMessenger(viewId) {
 
 window.viewIdsArray = [];
 
+// Work Orders Details Page - Viewer
 $(document).on("knack-view-render.view_2619", function(event, scene) {
   window.viewIdsArray.push("#view_2619");
   loadIframeMapMessenger("view_2619");
 });
 
+// Work Orders Details Page - Editable
 $(document).on("knack-view-render.view_2573", function(event, scene) {
   window.viewIdsArray.push("#view_2573");
   loadIframeMapMessenger("view_2573");
@@ -383,7 +385,14 @@ $(document).on("knack-view-render.view_2682", function(event, scene) {
   loadIframeMapMessenger("view_2682");
 });
 
-// Location Details Modal
+// Location Details Page - Viewer
+$(document).on("knack-view-render.view_2733", function(event, scene) {
+  window.viewIdsArray.push("#view_2733");
+  loadIframeMapMessenger("view_2733");
+  $("#kn-map-field_3300").hide(); // Remove map from Location Details
+});
+
+// Location Details Page - Editable
 $(document).on("knack-view-render.view_2609", function(event, scene) {
   window.viewIdsArray.push("#view_2609");
   loadIframeMapMessenger("view_2609");

--- a/knack/index.js
+++ b/knack/index.js
@@ -11,7 +11,6 @@ $(document).on("knack-page-render.any", function(event, page) {
   }
 });
 
-
 $(document).on("knack-scene-render.scene_428", function(event, page) {
   // update iframe src from detail field
   var iframe_url = $("span:contains('apps/webappviewer')").text();
@@ -288,7 +287,6 @@ $(document).on("knack-scene-render.scene_713", function(event, page) {
   }
 });
 
-
 $(document).on("knack-view-render.view_2491", function(event, page) {
   // Another copy of the find and replace attachment types script, this one for the manage requests
   // page
@@ -414,32 +412,64 @@ $(document).on("knack-view-render.view_2607", function(event, scene) {
 
 function bigButton(div_id, view_id, url, fa_icon, button_label, callback) {
   // create a large button
- 
-    $("<div/>", {
-      id: div_id,
-    }).appendTo("#" + view_id);
-    
-  $("#" + div_id).append("<a class='big-button' href='" + url + "'><div class='big-button-container'><span><i class='fa fa-" + fa_icon + "'></i></span><span> " + button_label + "</span></div></a>");
 
-  if(callback) callback();
+  $("<div/>", {
+    id: div_id
+  }).appendTo("#" + view_id);
+
+  $("#" + div_id).append(
+    "<a class='big-button' href='" +
+      url +
+      "'><div class='big-button-container'><span><i class='fa fa-" +
+      fa_icon +
+      "'></i></span><span> " +
+      button_label +
+      "</span></div></a>"
+  );
+
+  if (callback) callback();
 }
-    //>>>HOME TAB BUTTONS
-$(document).on('knack-view-render.view_2621', function(event, page) {
+//>>>HOME TAB BUTTONS
+$(document).on("knack-view-render.view_2621", function(event, page) {
   // create large button on the home page
-    bigButton('work-orders-markings', 'view_2621', "https://atd.knack.com/signs-markings#work-orders-markings/markings/", "road", "Work Orders | Markings");
+  bigButton(
+    "work-orders-markings",
+    "view_2621",
+    "https://atd.knack.com/signs-markings#work-orders-markings/markings/",
+    "road",
+    "Work Orders | Markings"
+  );
 });
 
-$(document).on('knack-view-render.view_2628', function(event, page) {
-    // create large button on the home page
-    bigButton('work-orders-signs', 'view_2628', "https://atd.knack.com/signs-markings#work-order-signs/", "flag", "Work Orders | Signs");
+$(document).on("knack-view-render.view_2628", function(event, page) {
+  // create large button on the home page
+  bigButton(
+    "work-orders-signs",
+    "view_2628",
+    "https://atd.knack.com/signs-markings#work-order-signs/",
+    "flag",
+    "Work Orders | Signs"
+  );
 });
 
-$(document).on('knack-view-render.view_2629', function(event, page) {
-    // create large button on the home page
-    bigButton('service-requests-signs', 'view_2629', "https://atd.knack.com/signs-markings#service-requests-signs/", "comments", "Service Requests | Signs");
+$(document).on("knack-view-render.view_2629", function(event, page) {
+  // create large button on the home page
+  bigButton(
+    "service-requests-signs",
+    "view_2629",
+    "https://atd.knack.com/signs-markings#service-requests-signs/",
+    "comments",
+    "Service Requests | Signs"
+  );
 });
 
-$(document).on('knack-view-render.view_2630', function(event, page) {
-    // create large button on the home page
-    bigButton('availability', 'view_2630', "https://atd.knack.com/street-banners#home/", "flag-o", "Program | Street Banners");
+$(document).on("knack-view-render.view_2630", function(event, page) {
+  // create large button on the home page
+  bigButton(
+    "availability",
+    "view_2630",
+    "https://atd.knack.com/street-banners#home/",
+    "flag-o",
+    "Program | Street Banners"
+  );
 });

--- a/knack/index.js
+++ b/knack/index.js
@@ -385,17 +385,10 @@ $(document).on("knack-view-render.view_2682", function(event, scene) {
   loadIframeMapMessenger("view_2682");
 });
 
-// Location Details Page - Viewer
+// Location Details Page - Viewer & Editable
 $(document).on("knack-view-render.view_2733", function(event, scene) {
   window.viewIdsArray.push("#view_2733");
   loadIframeMapMessenger("view_2733");
-  $("#kn-map-field_3300").hide(); // Remove map from Location Details
-});
-
-// Location Details Page - Editable
-$(document).on("knack-view-render.view_2609", function(event, scene) {
-  window.viewIdsArray.push("#view_2609");
-  loadIframeMapMessenger("view_2609");
   $("#kn-map-field_3300").hide(); // Remove map from Location Details
 });
 


### PR DESCRIPTION
_Closes #88_

This PR is attempting to make sure we have properly inventoried all view IDs were maps belong with considerations for both the Technician/Editing role (Test Technician) & the Viewer role (Test Viewer)

## Work Order Details Page - Editable - view_2573
![Screen Shot 2019-07-10 at 6 52 09 PM](https://user-images.githubusercontent.com/5697474/61012364-dbf65100-a343-11e9-9cc7-91b4d3512fe2.png)

## Work Order Details Page - Viewable - view_2619
_NOTE: on this one, we shouldn't be displaying the Red select location pin, as we currently are. We should only see the fixed pins. Need to figure out a work around here that doesn't break the editor view_
![Screen Shot 2019-07-10 at 6 46 20 PM](https://user-images.githubusercontent.com/5697474/61012202-127f9c00-a343-11e9-9adc-50b48a79ee89.png)

## Location Details - Editable - ~view_2609~ view_2733  
View 2609 is the Edit button. That only shows in the Editable mode. Both the edit and view Locations Details pages have view_2733. So we can use the same viewId for both technician and viewer roles in this case.

![Screen Shot 2019-07-10 at 6 56 15 PM](https://user-images.githubusercontent.com/5697474/61012492-6b9bff80-a344-11e9-9bdb-e90fbe6b8db5.png)
 
## Location Details - Viewable - view_2733  

![Screen Shot 2019-07-10 at 6 33 21 PM](https://user-images.githubusercontent.com/5697474/61012214-1e6b5e00-a343-11e9-8667-8512a0dd8808.png)

## Edit Location - view_2682

![Screen Shot 2019-07-10 at 6 56 45 PM](https://user-images.githubusercontent.com/5697474/61012510-87070a80-a344-11e9-95c9-492dc1908118.png)
