### PR TITLE
Remove commented lines of code that re-center map

### DIFF
--- a/src/SelectLocation.js
+++ b/src/SelectLocation.js
@@ -118,10 +118,8 @@ export default class SelectLocation extends Component {
   signClick = id => {
     // set state.sign for Popup parameters in render, center map to clicked sign
     const clickedSign = this.state.signs.find(sign => sign.id === id);
-    // const newCenter = [clickedSign.lng, clickedSign.lat];
     this.setState({
       activeSign: clickedSign
-      // center: newCenter
     });
   };
 


### PR DESCRIPTION
This change was left out of the merge of branch #98. This PR removes two lines of code that were commented out to disable the map from re-centering on a Marker upon clicking it to see the popup feature.

@mateoclarke Tagged you so you see this PR and merge.