### PR TITLE
Update iframe src for Signs & Markings SRs

### DIFF
--- a/knack/index.js
+++ b/knack/index.js
@@ -15,6 +15,10 @@ $(document).on("knack-scene-render.scene_1014", function(event, page) {
   // update iframe src from detail field
   var iframe_url = $("span:contains('apps/webappviewer')").text();
   $("#csr_view").attr("src", iframe_url);
+  
+  // hide the url vield, we don't need it after extracting the value
+  $("#view_2528").hide();
+
 });
 
 function insertRecord(data, scene, view) {

--- a/knack/index.js
+++ b/knack/index.js
@@ -11,14 +11,8 @@ $(document).on("knack-page-render.any", function(event, page) {
   }
 });
 
-$(document).on("knack-scene-render.scene_428", function(event, page) {
+$(document).on("knack-scene-render.scene_1014", function(event, page) {
   // update iframe src from detail field
-  var iframe_url = $("span:contains('apps/webappviewer')").text();
-  $("#csr_view").attr("src", iframe_url);
-});
-
-$(document).on("knack-scene-render.scene_501", function(event, page) {
-  //  update iframe src from detail field
   var iframe_url = $("span:contains('apps/webappviewer')").text();
   $("#csr_view").attr("src", iframe_url);
 });


### PR DESCRIPTION
Fixes #129. In the SR details page, we use an iframe to display an embedded arcgis online map on the service request details page, with a pin dropped at the SR location. We copied the code for this from the Data Tracker, and this PR updates the jquery that sets the iframe `src`.

