### PR TITLE
Hide latitude/longitude fields

### DIFF
--- a/knack/index.css
+++ b/knack/index.css
@@ -116,15 +116,17 @@ a.small-button {
   font-weight: 900;
 }
 
-/* Make buttons with type="submit" bigger */
-button[type="submit"] {
-  height: 64px !important;
-  font-size: 32px !important;
-  min-width: fit-content;
-  width: 100%;
-}
+@media (max-width: 800px) {
+  /* Make buttons with type="submit" bigger */
+  button[type="submit"] {
+    height: 64px !important;
+    font-size: 32px !important;
+    min-width: fit-content;
+    width: 100%;
+  }
 
-/* Override width set for submit buttons to prevent overlaying map controls */
-#lat-lon-form > form > div > button {
-  width: 50%;
+  /* Override width set for submit buttons to prevent overlaying map controls */
+  #lat-lon-form > form > div > button {
+    width: 50%;
+  }
 }

--- a/knack/index.css
+++ b/knack/index.css
@@ -31,32 +31,12 @@ div.view_2465 .field_3174 {
 #lat-lon-form {
   color: white;
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 1);
-  margin-top: -150px;
+  margin-top: -145px;
   padding-bottom: 40px;
 }
 
 #lat-lon-form button {
   margin-left: +4px;
-}
-
-#lat-lon-form label.help {
-  /* add id to second label.help to target it */
-  margin-top: -50px !important;
-  font-weight: bold;
-  font-size: 13px;
-  margin-top: 1px;
-}
-
-#lat-lon-form #latitude {
-  width: 190px;
-}
-
-#kn-input-field_3300 > div > div:nth-child(2) > input {
-  margin-left: -190px;
-}
-
-#kn-input-field_3300 > div > div:nth-child(2) > label {
-  margin-left: -190px;
 }
 
 .big-button-container {

--- a/knack/index.css
+++ b/knack/index.css
@@ -123,3 +123,8 @@ button[type="submit"] {
   min-width: fit-content;
   width: 100%;
 }
+
+/* Override width set for submit buttons to prevent overlaying map controls */
+#lat-lon-form > form > div > button {
+  width: 50%;
+}

--- a/knack/index.css
+++ b/knack/index.css
@@ -115,3 +115,8 @@ a.small-button {
   vertical-align: middle;
   font-weight: 900;
 }
+
+/* Make buttons with type="submit" bigger */
+button[type="submit"] {
+  color: red !important;
+}

--- a/knack/index.css
+++ b/knack/index.css
@@ -118,5 +118,8 @@ a.small-button {
 
 /* Make buttons with type="submit" bigger */
 button[type="submit"] {
-  color: red !important;
+  height: 64px !important;
+  font-size: 32px !important;
+  min-width: fit-content;
+  width: 100%;
 }

--- a/knack/index.js
+++ b/knack/index.js
@@ -384,6 +384,8 @@ $(document).on("knack-scene-render.scene_1028", function(event, scene) {
   $form.attr("id", "lat-lon-form");
   $form.detach();
   $("#view_2572").prepend($form);
+  // Hide Latitude/Longitude fields and labels overlaying map
+  $("#kn-input-field_3300 > div").hide();
 });
 
 $(document).on("knack-view-render.view_2607", function(event, scene) {


### PR DESCRIPTION
This PR closes #209. The lat/lon fields were hidden and the styles for the hidden elements were removed. The submit button shifted slightly after hiding the other form elements so the margin-top was adjusted to keep it in place.

### Map without lat/lon fields
![Screen Shot 2019-08-29 at 12 20 29 PM](https://user-images.githubusercontent.com/37249039/63962274-28aefc00-ca58-11e9-9810-f1aacd72a517.png)
