### PR TITLE
Knack iFrame | Update Netlify url to avoid redirect through http address

### DIFF
--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -34,7 +34,7 @@
     // Add React app as iframe if iframe doesn't already exist
     if ($(myView + " #mapIFrame").length === 0) {
       https: $(
-        '<iframe src="https://atd-knack-signs-markings.netlify.com/" frameborder="0" scrolling="yes" id="mapIFrame" \
+        '<iframe src="https://atd-knack-signs-markings.netlify.app/" frameborder="0" scrolling="yes" id="mapIFrame" \
     style="width: 100%;height: 523px;"></iframe>'
       ).appendTo($viewSelector);
     }


### PR DESCRIPTION
This PR updates the source url for the iFrame map that embedded in the Knack Signs and Markings app. After Netlify updated their url format, a redirect started occurring as shown in the screenshot below. Not sure why this didn't surface earlier, but the only difference that I can think of is the migration to the new Knack builder.

The error in the Knack app
![Screen Shot 2021-04-29 at 10 02 46 AM](https://user-images.githubusercontent.com/37249039/116578265-dc742900-a8d6-11eb-82ad-33c441831719.png)

The redirect happening when accessing https://atd-knack-signs-markings.netlify.com/
![Screen Shot 2021-04-29 at 10 29 16 AM](https://user-images.githubusercontent.com/37249039/116578346-ef86f900-a8d6-11eb-87ba-ab4f4efd5043.png)

