### PR TITLE
Render signs on map 

### DIFF
--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -114,6 +114,7 @@
           signsMarkerMessage.payload.location.latitude = locationField.latitude;
           signsMarkerMessage.payload.location.longitude =
             locationField.longitude;
+          signsMarkerMessage.payload.locationRecordId = recordId;
         })
         .then(function () {
           console.log("requesting records for work order id ", workOrderId);

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -7,8 +7,9 @@
 (function () {
   var myView = window.viewIdsArray.shift(0);
 
-  // const nextAppUrl = "https://deploy-preview-326--nextjs-knack-signs-markings.netlify.app/";
-  const nextAppUrl = "http://localhost:3000";
+  const nextAppUrl =
+    "https://deploy-preview-327--nextjs-knack-signs-markings.netlify.app/";
+  // const nextAppUrl = "http://localhost:3000";
 
   // Import jQuery into this file from CDN
   // https://stackoverflow.com/questions/34338411/how-to-import-jquery-using-es6-syntax
@@ -111,7 +112,8 @@
       })
         .then(function (res) {
           var locationField = res["field_3300_raw"];
-          signsMarkerMessage.payload.location.latitude = locationField?.latitude;
+          signsMarkerMessage.payload.location.latitude =
+            locationField?.latitude;
           signsMarkerMessage.payload.location.longitude =
             locationField?.longitude;
           signsMarkerMessage.payload.locationRecordId = recordId;

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -96,7 +96,10 @@
         message: "KNACK_LOCATION_DETAILS",
         payload: {
           records: [],
-          location: [],
+          location: {
+            longitude: undefined,
+            latitude: undefined,
+          },
         },
       };
 
@@ -107,11 +110,11 @@
         headers: headers,
       })
         .then(function (res) {
-          var locationField = res["field_3300_raw"]; // check if this is undefined
-          signsMarkerMessage.location = [
-            locationField.latitude,
-            locationField.longitude,
-          ];
+          var locationField = res["field_3300_raw"];
+          signsMarkerMessage.payload.location.longitude =
+            locationField.latitude;
+          signsMarkerMessage.payload.location.longitude =
+            locationField.longitude;
         })
         .then(function () {
           console.log("requesting records for work order id ", workOrderId);
@@ -121,7 +124,7 @@
             headers: headers,
           }).then(function (res) {
             var records = res.records;
-            signsMarkerMessage.records = records;
+            signsMarkerMessage.payload.records = records;
             sendMessageToApp(signsMarkerMessage, locationViewIFrame);
           });
         })
@@ -153,7 +156,6 @@
             message: "WORK_ORDER_SIGNS",
             payload: {
               records: res.records,
-              location: [],
               workOrderId: recordId,
             },
           };
@@ -186,8 +188,10 @@
           var locationMessage = {
             message: "EDIT_LOCATION",
             payload: {
-              records: [],
-              location: [locationField.latitude, locationField.longitude],
+              location: {
+                longitude: locationField.longitude,
+                latitude: locationField.latitude,
+              },
             },
           };
           sendMessageToApp(locationMessage, editLocationIframe);
@@ -227,9 +231,10 @@
       const geolocationMessage = {
         message: "KNACK_GEOLOCATION",
         payload: {
-          records: [],
-          location: [],
-          geolocation: [position.coords.latitude, position.coords.longitude],
+          geolocation: {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          },
         },
       };
 

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -111,8 +111,7 @@
       })
         .then(function (res) {
           var locationField = res["field_3300_raw"];
-          signsMarkerMessage.payload.location.longitude =
-            locationField.latitude;
+          signsMarkerMessage.payload.location.latitude = locationField.latitude;
           signsMarkerMessage.payload.location.longitude =
             locationField.longitude;
         })
@@ -125,6 +124,7 @@
           }).then(function (res) {
             var records = res.records;
             signsMarkerMessage.payload.records = records;
+            signsMarkerMessage.payload.workOrderId = workOrderId;
             sendMessageToApp(signsMarkerMessage, locationViewIFrame);
           });
         })

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -111,9 +111,9 @@
       })
         .then(function (res) {
           var locationField = res["field_3300_raw"];
-          signsMarkerMessage.payload.location.latitude = locationField.latitude;
+          signsMarkerMessage.payload.location.latitude = locationField?.latitude;
           signsMarkerMessage.payload.location.longitude =
-            locationField.longitude;
+            locationField?.longitude;
           signsMarkerMessage.payload.locationRecordId = recordId;
         })
         .then(function () {
@@ -190,8 +190,8 @@
             message: "EDIT_LOCATION",
             payload: {
               location: {
-                longitude: locationField.longitude,
-                latitude: locationField.latitude,
+                longitude: locationField?.longitude,
+                latitude: locationField?.latitude,
               },
             },
           };

--- a/signs-work-order-map/app/globals.scss
+++ b/signs-work-order-map/app/globals.scss
@@ -40,3 +40,4 @@ a {
     color-scheme: dark;
   }
 }
+@import "../node_modules/bootstrap/scss/bootstrap";

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -1,73 +1,31 @@
 "use client";
+import { useMemo } from "react";
 import styles from "./page.module.css";
 import Map from "@/components/Map";
 import { KnackRecord, Sign } from "@/types/map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
 
-const testpayload = {
-  location: undefined,
-  message: "WORK_ORDER_SIGNS",
-  records: [
-    {
-      field_3297: 202,
-      field_3297_raw: 202,
-      field_3300: "4702 Oldfort Hill Dr<br />Austin, Texas 78723",
-      field_3300_raw: {
-        city: "Austin",
-        country: "United States",
-        full: "4702 Oldfort Hill Dr Austin, Texas 78723",
-        latitude: 30.286771,
-        longitude: -97.675177,
-        state: "Texas",
-        street: "4702 Oldfort Hill Dr",
-        street2: null,
-        zip: "78723",
-      },
-      field_3301:
-        '<span class="5d13ae66d3186524eaea0b20">Librado Murrieta</span>',
-      field_3301_raw: [
-        { id: "5d13ae66d3186524eaea0b20", identifier: "Librado Murrieta" },
-      ],
-      field_3302: "08/01/2019",
-      field_3302_raw: {
-        am_pm: "AM",
-        date: "08/01/2019",
-        date_formatted: "08/01/2019",
-        hours: "12",
-        iso_timestamp: "2019-08-01T00:00:00.000Z",
-        minutes: "00",
-        proper_iso_timestamp: "2019-08-01T05:00:00.000Z",
-        proper_unix_timestamp: 1564635600000,
-        time: 0,
-        timestamp: "08/01/2019 12:00 am",
-        unix_timestamp: 1564617600000,
-      },
-      field_3378: "",
-      field_3378_raw: "",
-      field_3425: 1,
-      field_3425_raw: 1,
-      id: "5d433cc8b760fc0011a42f77",
-    },
-  ],
-};
-
-const formatSignsRecords = (records: KnackRecord[]): Sign[] => {
-  console.log(records);
-  return records.map((sign) => ({
-    id: sign.id,
-    lat: sign.field_3300_raw.latitude,
-    lng: sign.field_3300_raw.longitude,
-    spatialId: sign.field_3300_raw.longitude,
-  }));
-};
+const formatSignsRecords = (records: KnackRecord[]): Sign[] =>
+  useMemo(() => {
+    console.log(records);
+    if (!records || records.length < 1) {
+      return [];
+    }
+    return records.map((sign) => ({
+      id: sign.id,
+      lat: sign.field_3300_raw.latitude,
+      lng: sign.field_3300_raw.longitude,
+      spatialId: sign.field_3300_raw.longitude,
+    }));
+  }, [records]);
 
 export default function Home() {
-  //const knackPayload = useIFrameMessenger();
-  const knackPayload = testpayload;
-  console.log(testpayload);
+  const knackPayload = useIFrameMessenger();
+  // const knackPayload = testpayload;
 
-  const location = knackPayload.location;
-  const signs = formatSignsRecords(knackPayload.records);
+  const location = knackPayload?.location;
+  const signs = formatSignsRecords(knackPayload?.records);
+  console.log(signs);
   const messageType = knackPayload?.message;
 
   return (

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -5,7 +5,7 @@ import Map from "@/components/Map";
 import { KnackRecord, Sign } from "@/types/map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
 
-const formatSignsRecords = (records: KnackRecord[]): Sign[] =>
+const formatSignsRecords = (records: KnackRecord[] | undefined): Sign[] =>
   useMemo(() => {
     console.log(records);
     if (!records || records.length < 1) {

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -23,8 +23,10 @@ export default function Home() {
   const knackPayload = useIFrameMessenger();
   // const knackPayload = testpayload;
 
-  const location = knackPayload?.location;
-  const signs = formatSignsRecords(knackPayload?.records);
+  console.log(knackPayload)
+
+  const location = knackPayload?.payload?.location;
+  const signs = formatSignsRecords(knackPayload?.payload?.records);
   console.log(signs);
   const messageType = knackPayload?.message;
 

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import styles from "./page.module.css";
-import Map, {Sign} from "@/components/Map";
+import Map, { Sign } from "@/components/Map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
 
 const testpayload = {
@@ -50,16 +50,14 @@ const testpayload = {
   ],
 };
 
-const formatSignsRecords = (records) => {
+const formatSignsRecords = (records): Sign[] => {
   console.log(records);
-  return records.map((sign) => {
-    const signObj = {};
-    signObj["id"] = sign.id;
-    signObj["lat"] = sign.field_3300_raw.latitude;
-    signObj["lng"] = sign.field_3300_raw.longitude;
-    signObj["spatialId"] = sign.field_3297;
-    return signObj;
-  });
+  return records.map((sign) => ({
+    id: sign.id,
+    lat: sign.field_3300_raw.latitude,
+    lng: sign.field_3300_raw.longitude,
+    spatialId: sign.field_3300_raw.longitude,
+  }));
 };
 
 export default function Home() {

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -1,21 +1,16 @@
 "use client";
 import styles from "./page.module.css";
 import Map from "@/components/Map";
-import { KnackRecord, Sign, KnackToIFrameMessage } from "@/types/map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
-import { formatSignsRecords } from "@/utils/mapUtils";
-
-
+import { formatSignsRecords, formatLocation } from "@/utils/mapUtils";
 
 export default function Home() {
   const knackPayload = useIFrameMessenger();
 
   console.log(knackPayload);
 
-  const location = knackPayload?.payload?.location; // turn this into a format location function
-  // because we should zoom to location if it exists
+  const location = formatLocation(knackPayload);
   const signs = formatSignsRecords(knackPayload);
-  console.log(signs);
   const messageType = knackPayload?.message;
 
   return (

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -3,18 +3,79 @@ import styles from "./page.module.css";
 import Map from "@/components/Map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
 
-export default function Home() {
-  const knackPayload = useIFrameMessenger();
+const testpayload = {
+  location: [],
+  message: "WORK_ORDER_SIGNS",
+  records: [
+    {
+      field_3297: 202,
+      field_3297_raw: 202,
+      field_3300: "4702 Oldfort Hill Dr<br />Austin, Texas 78723",
+      field_3300_raw: {
+        city: "Austin",
+        country: "United States",
+        full: "4702 Oldfort Hill Dr Austin, Texas 78723",
+        latitude: 30.286771,
+        longitude: -97.675177,
+        state: "Texas",
+        street: "4702 Oldfort Hill Dr",
+        street2: null,
+        zip: "78723",
+      },
+      field_3301:
+        '<span class="5d13ae66d3186524eaea0b20">Librado Murrieta</span>',
+      field_3301_raw: [
+        { id: "5d13ae66d3186524eaea0b20", identifier: "Librado Murrieta" },
+      ],
+      field_3302: "08/01/2019",
+      field_3302_raw: {
+        am_pm: "AM",
+        date: "08/01/2019",
+        date_formatted: "08/01/2019",
+        hours: "12",
+        iso_timestamp: "2019-08-01T00:00:00.000Z",
+        minutes: "00",
+        proper_iso_timestamp: "2019-08-01T05:00:00.000Z",
+        proper_unix_timestamp: 1564635600000,
+        time: 0,
+        timestamp: "08/01/2019 12:00 am",
+        unix_timestamp: 1564617600000,
+      },
+      field_3378: "",
+      field_3378_raw: "",
+      field_3425: 1,
+      field_3425_raw: 1,
+      id: "5d433cc8b760fc0011a42f77",
+    },
+  ],
+};
 
-  console.log(knackPayload)
+const formatSignsRecords = (records) => {
+  console.log(records);
+  return records.map((sign) => {
+    const signObj = {};
+    signObj["id"] = sign.id;
+    signObj["lat"] = sign.field_3300_raw.latitude;
+    signObj["lng"] = sign.field_3300_raw.longitude;
+    signObj["spatialId"] = sign.field_3297;
+    return signObj;
+  });
+};
+
+export default function Home() {
+  //const knackPayload = useIFrameMessenger();
+  const knackPayload = testpayload;
+  console.log(testpayload);
 
   const location = knackPayload?.location;
+  const signs = formatSignsRecords(knackPayload.records);
+  const messageType = knackPayload?.message;
 
   return (
     <div className={styles.page}>
       <main className={styles.main}>
         <div className={styles.map}>
-          <Map location={location} />
+          <Map messageType={messageType} location={location} signs={signs} />
         </div>
       </main>
     </div>

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -2,15 +2,15 @@
 import styles from "./page.module.css";
 import Map from "@/components/Map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
-import { formatSignsRecords, formatLocation } from "@/utils/mapUtils";
+import { useFormatSignsRecords, useFormatLocation } from "@/utils/mapUtils";
 
 export default function Home() {
   const knackPayload = useIFrameMessenger();
 
   console.log(knackPayload);
 
-  const location = formatLocation(knackPayload);
-  const signs = formatSignsRecords(knackPayload);
+  const location = useFormatLocation(knackPayload);
+  const signs = useFormatSignsRecords(knackPayload);
 
   return (
     <div className={styles.page}>

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -11,13 +11,12 @@ export default function Home() {
 
   const location = formatLocation(knackPayload);
   const signs = formatSignsRecords(knackPayload);
-  const messageType = knackPayload?.message;
 
   return (
     <div className={styles.page}>
       <main className={styles.main}>
         <div className={styles.map}>
-          <Map messageType={messageType} location={location} signs={signs} />
+          <Map location={location} signs={signs} />
         </div>
       </main>
     </div>

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import styles from "./page.module.css";
-import Map, { Sign } from "@/components/Map";
+import Map from "@/components/Map";
+import { KnackRecord, Sign } from "@/types/map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
 
 const testpayload = {
-  location: [],
+  location: undefined,
   message: "WORK_ORDER_SIGNS",
   records: [
     {
@@ -50,7 +51,7 @@ const testpayload = {
   ],
 };
 
-const formatSignsRecords = (records): Sign[] => {
+const formatSignsRecords = (records: KnackRecord[]): Sign[] => {
   console.log(records);
   return records.map((sign) => ({
     id: sign.id,
@@ -65,7 +66,7 @@ export default function Home() {
   const knackPayload = testpayload;
   console.log(testpayload);
 
-  const location = knackPayload?.location;
+  const location = knackPayload.location;
   const signs = formatSignsRecords(knackPayload.records);
   const messageType = knackPayload?.message;
 

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import styles from "./page.module.css";
-import Map from "@/components/Map";
+import Map, {Sign} from "@/components/Map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
 
 const testpayload = {

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -2,31 +2,38 @@
 import { useMemo } from "react";
 import styles from "./page.module.css";
 import Map from "@/components/Map";
-import { KnackRecord, Sign } from "@/types/map";
+import { KnackRecord, Sign, KnackToIFrameMessage } from "@/types/map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
 
-const formatSignsRecords = (records: KnackRecord[] | undefined): Sign[] =>
+const formatSignsRecords = (
+  knackPayload: KnackToIFrameMessage | null
+): Sign[] =>
   useMemo(() => {
-    console.log(records);
-    if (!records || records.length < 1) {
+    if (!knackPayload) return [];
+    if (
+      knackPayload?.message === "EDIT_LOCATION" ||
+      knackPayload?.message === "KNACK_GEOLOCATION"
+    ) {
       return [];
     }
-    return records.map((sign) => ({
+    console.log(knackPayload?.payload?.records);
+    return knackPayload.payload.records.map((sign) => ({
       id: sign.id,
       lat: sign.field_3300_raw.latitude,
       lng: sign.field_3300_raw.longitude,
-      spatialId: sign.field_3300_raw.longitude,
+      spatialId: sign.field_3297,
+      workOrderId: knackPayload.payload.workOrderId,
     }));
-  }, [records]);
+  }, [knackPayload]);
 
 export default function Home() {
   const knackPayload = useIFrameMessenger();
   // const knackPayload = testpayload;
 
-  console.log(knackPayload)
+  console.log(knackPayload);
 
   const location = knackPayload?.payload?.location;
-  const signs = formatSignsRecords(knackPayload?.payload?.records);
+  const signs = formatSignsRecords(knackPayload);
   console.log(signs);
   const messageType = knackPayload?.message;
 

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -1,38 +1,19 @@
 "use client";
-import { useMemo } from "react";
 import styles from "./page.module.css";
 import Map from "@/components/Map";
 import { KnackRecord, Sign, KnackToIFrameMessage } from "@/types/map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
+import { formatSignsRecords } from "@/utils/mapUtils";
 
-const formatSignsRecords = (
-  knackPayload: KnackToIFrameMessage | null
-): Sign[] =>
-  useMemo(() => {
-    if (!knackPayload) return [];
-    if (
-      knackPayload?.message === "EDIT_LOCATION" ||
-      knackPayload?.message === "KNACK_GEOLOCATION"
-    ) {
-      return [];
-    }
-    console.log(knackPayload?.payload?.records);
-    return knackPayload.payload.records.map((sign) => ({
-      id: sign.id,
-      lat: sign.field_3300_raw.latitude,
-      lng: sign.field_3300_raw.longitude,
-      spatialId: sign.field_3297,
-      workOrderId: knackPayload.payload.workOrderId,
-    }));
-  }, [knackPayload]);
+
 
 export default function Home() {
   const knackPayload = useIFrameMessenger();
-  // const knackPayload = testpayload;
 
   console.log(knackPayload);
 
-  const location = knackPayload?.payload?.location;
+  const location = knackPayload?.payload?.location; // turn this into a format location function
+  // because we should zoom to location if it exists
   const signs = formatSignsRecords(knackPayload);
   console.log(signs);
   const messageType = knackPayload?.message;

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -87,18 +87,19 @@ export default function Map({ location, signs, messageType }: MapProps) {
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
     >
-      {/* <Marker
-        longitude={mapLatLon.longitude}
-        latitude={mapLatLon.latitude}
-           // draggable
-      />
-        */
-        }
+      {signs.length < 1 && mapLatLon?.latitude && mapLatLon?.longitude && (
+        <Marker
+          longitude={mapLatLon.longitude}
+          latitude={mapLatLon.latitude}
+          // draggable
+          //red?
+        />
+      )}
 
       {signPins}
 
       {
-        // when do we show location vs signs? based on message type?
+        // when do we show location vs signs? when there are no signs?
         /* {location?.latitude && location?.longitude && (
         <Marker latitude={location.latitude} longitude={location.longitude} />
       )} */

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -50,8 +50,11 @@ export default function Map({ location, signs }: MapProps) {
     if (!mapRef?.current || !bounds) {
       return;
     }
+
     mapRef.current.fitBounds(bounds, {
       padding: 100,
+      maxZoom: 16,
+      duration: 0,
     });
   }, [bounds]);
 

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -26,7 +26,6 @@ export default function Map({ location, signs, messageType }: MapProps) {
     const longitude = +event.viewState.longitude.toFixed(
       MAP_COORDINATE_PRECISION
     );
-    console.log(latitude, longitude);
     setMapLatLon({
       latitude,
       longitude,
@@ -53,6 +52,7 @@ export default function Map({ location, signs, messageType }: MapProps) {
           longitude={sign.lng}
           latitude={sign.lat}
           anchor="bottom"
+          color={sign.locationDetailPage ? "red" : undefined}
           onClick={(e) => {
             // If we let the click event propagates to the map, it will immediately close the popup
             // with `closeOnClick: true`
@@ -69,7 +69,9 @@ export default function Map({ location, signs, messageType }: MapProps) {
     if (!mapRef?.current || !bounds) {
       return;
     }
-    mapRef.current.fitBounds(bounds);
+    mapRef.current.fitBounds(bounds, {
+      padding: 100,
+    });
   }, [bounds]);
 
   return (
@@ -79,8 +81,9 @@ export default function Map({ location, signs, messageType }: MapProps) {
         latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
         longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
         zoom: DEFAULT_MAP_PAN_ZOOM.zoom,
-        bounds: bounds,
+        // bounds: bounds,
       }}
+      cooperativeGestures={true}
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
     >

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -2,34 +2,14 @@
 import { useCallback, useState, useMemo } from "react";
 import MapGL, { Marker, ViewStateChangeEvent } from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
-import bbox from "@turf/bbox";
-import { lineString } from "@turf/helpers";
 import SignPopup from "./SignPopup";
-
+import { MapProps, LatLon, Sign } from "@/types/map";
+import { formatBounds } from "@/utils/mapUtils";
 import {
   DEFAULT_MAP_PARAMS,
   DEFAULT_MAP_PAN_ZOOM,
   MAP_COORDINATE_PRECISION,
 } from "@/config/map";
-
-interface LatLon {
-  latitude: number;
-  longitude: number;
-}
-
-interface MapProps {
-  location: [number, number] | undefined;
-  signs: any;
-  messageType: string | undefined; // refine this more to only be one of the specific messages?
-}
-
-export interface Sign {
-  id: string;
-  lng: number;
-  lat: number;
-  spatialId: number;
-  workOrderId: string;
-}
 
 export default function Map({ location, signs, messageType }: MapProps) {
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
@@ -58,16 +38,7 @@ export default function Map({ location, signs, messageType }: MapProps) {
     longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
   });
 
-  const signArray = useMemo(() => {
-    return signs.map((sign: Sign) => [sign.lng, sign.lat]);
-  }, [signs]);
-
-  const lineStringFeature =
-    signArray.length < 2
-      ? lineString([signArray[0], [signArray[0][0], signArray[0][1]]])
-      : lineString(signArray);
-
-  const [minLng, minLat, maxLng, maxLat] = bbox(lineStringFeature);
+  const bounds = formatBounds(signs);
 
   const signPins = useMemo(
     () =>
@@ -95,7 +66,7 @@ export default function Map({ location, signs, messageType }: MapProps) {
         latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
         longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
         zoom: DEFAULT_MAP_PAN_ZOOM.zoom,
-        bounds: [minLng, minLat, maxLng, maxLat],
+        bounds: bounds,
       }}
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
@@ -108,9 +79,9 @@ export default function Map({ location, signs, messageType }: MapProps) {
 
       {signPins}
 
-      {/* {location && location[0] && (
+      {location && location[0] && (
         <Marker latitude={location[0]} longitude={location[1]} />
-      )} */}
+      )}
 
       {popupInfo && (
         <SignPopup popupInfo={popupInfo} setPopupInfo={setPopupInfo} />

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -1,12 +1,5 @@
 "use client";
-import {
-  useCallback,
-  useState,
-  useMemo,
-  useEffect,
-  useRef,
-  RefObject,
-} from "react";
+import { useCallback, useState, useMemo, useEffect, useRef } from "react";
 import MapGL, {
   MapRef,
   Marker,
@@ -99,8 +92,8 @@ export default function Map({ location, signs, messageType }: MapProps) {
 
       {signPins}
 
-      {location && location[0] && (
-        <Marker latitude={location[0]} longitude={location[1]} />
+      {location?.latitude && location?.longitude && (
+        <Marker latitude={location.latitude} longitude={location.longitude} />
       )}
 
       {popupInfo && (

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -1,11 +1,10 @@
 "use client";
 import { useCallback, useState, useMemo } from "react";
-import MapGL, {
-  Marker,
-  ViewStateChangeEvent,
-  Popup,
-} from "react-map-gl/mapbox";
+import MapGL, { Marker, ViewStateChangeEvent } from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
+import bbox from "@turf/bbox";
+import { lineString } from "@turf/helpers";
+import SignPopup from "./SignPopup";
 
 import {
   DEFAULT_MAP_PARAMS,
@@ -22,6 +21,14 @@ interface MapProps {
   location: [number, number] | undefined;
   signs: any;
   messageType: string | undefined; // refine this more to only be one of the specific messages?
+}
+
+export interface Sign {
+  id: string;
+  lng: number;
+  lat: number;
+  spatialId: number;
+  workOrderId: string;
 }
 
 export default function Map({ location, signs, messageType }: MapProps) {
@@ -52,11 +59,11 @@ export default function Map({ location, signs, messageType }: MapProps) {
     longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
   });
 
-  const pins = useMemo(
+  const signPins = useMemo(
     () =>
-      signs.map((sign, index) => (
+      signs.map((sign) => (
         <Marker
-          key={`marker-${index}`}
+          key={`marker-${sign.id}`}
           longitude={sign.lng}
           latitude={sign.lat}
           anchor="bottom"
@@ -64,12 +71,10 @@ export default function Map({ location, signs, messageType }: MapProps) {
             // If we let the click event propagates to the map, it will immediately close the popup
             // with `closeOnClick: true`
             e.originalEvent.stopPropagation();
+            console.log(sign);
             setPopupInfo(sign);
           }}
-        >
-          {/*<Pin />
-           */}
-        </Marker>
+        />
       )),
     []
   );
@@ -90,72 +95,17 @@ export default function Map({ location, signs, messageType }: MapProps) {
         // draggable
       /> */}
 
-      {pins}
+      {signPins}
 
       {/* {location && location[0] && (
         <Marker latitude={location[0]} longitude={location[1]} />
       )} */}
 
       {popupInfo && (
-        <Popup
-          anchor="top"
-          longitude={Number(popupInfo.lng)}
-          latitude={Number(popupInfo.lat)}
-          onClose={() => setPopupInfo(null)}
-          offset={[0, -20]}
-        >
-          <div>
-            <span>
-              <a
-                href={`https://atd.knack.com/signs-markings#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
-                  popupInfo.id
-                }`}
-                // ensure it doesn't open in the iframe
-                target="_top"
-              >
-                Location Detail Page
-              </a>
-            </span>
-            <br />
-            <span>Spatial ID: {popupInfo.spatialId}</span>
-            <br />
-            <span>Latitude: {popupInfo.lat}</span>
-            <br />
-            <span>Longitude: {popupInfo.lng}</span>
-          </div>
-        </Popup>
+        <SignPopup popupInfo={popupInfo} setPopupInfo={setPopupInfo} />
       )}
 
       <GeocoderControl position="top-left" marker={true} />
     </MapGL>
   );
 }
-
-/*
-                <Popup
-                  key={activeSign.id}
-                  coordinates={[activeSign.lng, activeSign.lat]}
-                  onClick={this.closePopup}
-                  offset={{ bottom: [0, -40] }}
-                >
-                  <div className="container popup">
-                    <span>
-                      <a
-                        href={`https://atd.knack.com/signs-markings#work-order-signs/view-work-orders-details-sign/${workOrderId}/view-work-order-signs-location-details/${
-                          activeSign.id
-                        }`}
-                        target="_top"
-                      >
-                        Location Detail Page
-                      </a>
-                    </span>
-                    <br />
-                    <span>Spatial ID: {activeSign.spatialId}</span>
-                    <br />
-                    <span>Latitude: {activeSign.lat}</span>
-                    <br />
-                    <span>Longitude: {activeSign.lng}</span>
-                  </div>
-                </Popup>
- *
- */

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -87,20 +87,22 @@ export default function Map({ location, signs, messageType }: MapProps) {
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
     >
-      {/* {!location.latitude && location.longitude && 
-        <Marker
-        longitude={location.longitude}
-        latitude={location.latitude}
-        color="pink"
-        anchor="bottom"
-        // draggable
-      /> */}
+      {/* <Marker
+        longitude={mapLatLon.longitude}
+        latitude={mapLatLon.latitude}
+           // draggable
+      />
+        */
+        }
 
       {signPins}
 
-      {location?.latitude && location?.longitude && (
+      {
+        // when do we show location vs signs? based on message type?
+        /* {location?.latitude && location?.longitude && (
         <Marker latitude={location.latitude} longitude={location.longitude} />
-      )}
+      )} */
+      }
 
       {popupInfo && (
         <SignPopup popupInfo={popupInfo} setPopupInfo={setPopupInfo} />

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -87,9 +87,12 @@ export default function Map({ location, signs, messageType }: MapProps) {
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
     >
-      {/* <Marker
-        longitude={mapLatLon.longitude}
-        latitude={mapLatLon.latitude}
+      {/* {!location.latitude && location.longitude && 
+        <Marker
+        longitude={location.longitude}
+        latitude={location.latitude}
+        color="pink"
+        anchor="bottom"
         // draggable
       /> */}
 

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -73,7 +73,6 @@ export default function Map({ location, signs, messageType }: MapProps) {
   );
 
   useEffect(() => {
-    console.log(mapRef.current);
     if (!mapRef?.current || !bounds) {
       return;
     }

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -1,6 +1,10 @@
 "use client";
-import { useCallback, useState, useMemo } from "react";
-import MapGL, { Marker, ViewStateChangeEvent } from "react-map-gl/mapbox";
+import { useCallback, useState, useMemo, useEffect, useRef } from "react";
+import MapGL, {
+  Marker,
+  ViewStateChangeEvent,
+  MapRef,
+} from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
 import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
@@ -32,7 +36,8 @@ export interface Sign {
 }
 
 export default function Map({ location, signs, messageType }: MapProps) {
-  console.log(signs);
+  console.log("SIGNS ", signs);
+  const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
   const onDrag = useCallback((event: ViewStateChangeEvent) => {
     // truncate values to our preferred precision
@@ -47,7 +52,7 @@ export default function Map({ location, signs, messageType }: MapProps) {
       latitude,
       longitude,
     });
-    // send location to Knack
+    // send location to Knack -- this shouldnt happen during certain views? or does it matter?
     window.parent.postMessage(
       { message: "LAT_LON_FIELDS", lat: latitude, lng: longitude },
       "*"
@@ -58,6 +63,34 @@ export default function Map({ location, signs, messageType }: MapProps) {
     latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
     longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
   });
+
+  const signArray = useMemo(() => {
+    return signs.map((sign: Sign) => [sign.lng, sign.lat]);
+  }, [signs]);
+
+  console.log(signArray, signArray.length, mapRef.current);
+
+  // const onClick = (event) => {
+  const lineStringFeature =
+    signArray.length < 2
+      ? lineString([signArray[0], [signArray[0][0], signArray[0][1]]])
+      : lineString(signArray);
+
+  console.log("feature", lineStringFeature);
+
+  useEffect(() => {
+    const [minLng, minLat, maxLng, maxLat] = bbox(lineStringFeature);
+    console.log(minLat, minLng, maxLat, maxLng);
+
+    mapRef.current?.fitBounds(
+      [
+        [minLng, minLat],
+        [maxLng, maxLat],
+      ],
+      { padding: 40, duration: 1000 }
+    );
+  }, [mapRef, lineStringFeature]);
+  // };
 
   const signPins = useMemo(
     () =>
@@ -76,11 +109,12 @@ export default function Map({ location, signs, messageType }: MapProps) {
           }}
         />
       )),
-    []
+    [signs]
   );
 
   return (
     <MapGL
+      ref={mapRef}
       initialViewState={{
         latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
         longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
@@ -88,6 +122,7 @@ export default function Map({ location, signs, messageType }: MapProps) {
       }}
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
+      // onClick={onClick}
     >
       {/* <Marker
         longitude={mapLatLon.longitude}

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -1,6 +1,10 @@
 "use client";
-import { useCallback, useState } from "react";
-import MapGL, { Marker, ViewStateChangeEvent } from "react-map-gl/mapbox";
+import { useCallback, useState, useMemo } from "react";
+import MapGL, {
+  Marker,
+  ViewStateChangeEvent,
+  Popup,
+} from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
 
 import {
@@ -16,9 +20,13 @@ interface LatLon {
 
 interface MapProps {
   location: [number, number] | undefined;
+  signs: any;
+  messageType: string | undefined; // refine this more to only be one of the specific messages?
 }
 
-export default function Map({ location }: MapProps) {
+export default function Map({ location, signs, messageType }: MapProps) {
+  console.log(signs);
+  const [popupInfo, setPopupInfo] = useState(null);
   const onDrag = useCallback((event: ViewStateChangeEvent) => {
     // truncate values to our preferred precision
     const latitude = +event.viewState.latitude.toFixed(
@@ -44,6 +52,28 @@ export default function Map({ location }: MapProps) {
     longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
   });
 
+  const pins = useMemo(
+    () =>
+      signs.map((sign, index) => (
+        <Marker
+          key={`marker-${index}`}
+          longitude={sign.lng}
+          latitude={sign.lat}
+          anchor="bottom"
+          onClick={(e) => {
+            // If we let the click event propagates to the map, it will immediately close the popup
+            // with `closeOnClick: true`
+            e.originalEvent.stopPropagation();
+            setPopupInfo(sign);
+          }}
+        >
+          {/*<Pin />
+           */}
+        </Marker>
+      )),
+    []
+  );
+
   return (
     <MapGL
       initialViewState={{
@@ -54,15 +84,17 @@ export default function Map({ location }: MapProps) {
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
     >
-      <Marker
+      {/* <Marker
         longitude={mapLatLon.longitude}
         latitude={mapLatLon.latitude}
         // draggable
-      />
+      /> */}
 
-      {location && location[0] && (
+      {pins}
+
+      {/* {location && location[0] && (
         <Marker latitude={location[0]} longitude={location[1]} />
-      )}
+      )} */}
 
       <GeocoderControl position="top-left" marker={true} />
     </MapGL>

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -8,7 +8,7 @@ import MapGL, {
 import GeocoderControl from "@/components/MapGeocoderControl";
 import SignPopup from "./SignPopup";
 import { MapProps, LatLon, Sign } from "@/types/map";
-import { createSignPins, formatBounds } from "@/utils/mapUtils";
+import { useCreateSignPins, useFormatBounds } from "@/utils/mapUtils";
 import {
   DEFAULT_MAP_PARAMS,
   DEFAULT_MAP_PAN_ZOOM,
@@ -42,9 +42,9 @@ export default function Map({ location, signs }: MapProps) {
     longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
   });
 
-  const bounds = formatBounds(signs);
+  const bounds = useFormatBounds(signs);
 
-  const signPins = createSignPins(signs, setPopupInfo);
+  const signPins = useCreateSignPins(signs, setPopupInfo);
 
   useEffect(() => {
     if (!mapRef?.current || !bounds) {

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -81,7 +81,6 @@ export default function Map({ location, signs }: MapProps) {
         latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
         longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
         zoom: DEFAULT_MAP_PAN_ZOOM.zoom,
-        // bounds: bounds,
       }}
       cooperativeGestures={true}
       {...DEFAULT_MAP_PARAMS}
@@ -99,6 +98,8 @@ export default function Map({ location, signs }: MapProps) {
       {signPins}
 
       {
+        // showing the location / geolocation will happen in a subsequent issue
+        console.log("location from payload: ", location)
         // when do we show location vs signs? when there are no signs?
         /* {location?.latitude && location?.longitude && (
         <Marker latitude={location.latitude} longitude={location.longitude} />

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -15,7 +15,7 @@ import {
   MAP_COORDINATE_PRECISION,
 } from "@/config/map";
 
-export default function Map({ location, signs, messageType }: MapProps) {
+export default function Map({ location, signs }: MapProps) {
   const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
   const onDrag = useCallback((event: ViewStateChangeEvent) => {

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useState, useMemo, useEffect, useRef } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 import MapGL, {
   MapRef,
   Marker,

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -8,7 +8,7 @@ import MapGL, {
 import GeocoderControl from "@/components/MapGeocoderControl";
 import SignPopup from "./SignPopup";
 import { MapProps, LatLon, Sign } from "@/types/map";
-import { formatBounds } from "@/utils/mapUtils";
+import { createSignPins, formatBounds } from "@/utils/mapUtils";
 import {
   DEFAULT_MAP_PARAMS,
   DEFAULT_MAP_PAN_ZOOM,
@@ -30,10 +30,10 @@ export default function Map({ location, signs }: MapProps) {
       latitude,
       longitude,
     });
-    // send location to Knack -- this shouldnt happen during certain views? or does it matter?
+    // send location to Knack
     window.parent.postMessage(
       { message: "LAT_LON_FIELDS", lat: latitude, lng: longitude },
-      "*"
+      "https://atd.knack.com"
     );
   }, []);
 
@@ -44,26 +44,7 @@ export default function Map({ location, signs }: MapProps) {
 
   const bounds = formatBounds(signs);
 
-  const signPins = useMemo(
-    () =>
-      signs.map((sign: Sign) => (
-        <Marker
-          key={`marker-${sign.id}`}
-          longitude={sign.lng}
-          latitude={sign.lat}
-          anchor="bottom"
-          color={sign.locationDetailPage ? "red" : undefined}
-          onClick={(e) => {
-            // If we let the click event propagates to the map, it will immediately close the popup
-            // with `closeOnClick: true`
-            e.originalEvent.stopPropagation();
-            console.log(sign);
-            setPopupInfo(sign);
-          }}
-        />
-      )),
-    [signs]
-  );
+  const signPins = createSignPins(signs, setPopupInfo);
 
   useEffect(() => {
     if (!mapRef?.current || !bounds) {

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -1,10 +1,6 @@
 "use client";
-import { useCallback, useState, useMemo, useEffect, useRef } from "react";
-import MapGL, {
-  Marker,
-  ViewStateChangeEvent,
-  MapRef,
-} from "react-map-gl/mapbox";
+import { useCallback, useState, useMemo } from "react";
+import MapGL, { Marker, ViewStateChangeEvent } from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
 import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
@@ -36,8 +32,6 @@ export interface Sign {
 }
 
 export default function Map({ location, signs, messageType }: MapProps) {
-  console.log("SIGNS ", signs);
-  const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
   const onDrag = useCallback((event: ViewStateChangeEvent) => {
     // truncate values to our preferred precision
@@ -68,29 +62,12 @@ export default function Map({ location, signs, messageType }: MapProps) {
     return signs.map((sign: Sign) => [sign.lng, sign.lat]);
   }, [signs]);
 
-  console.log(signArray, signArray.length, mapRef.current);
-
-  // const onClick = (event) => {
   const lineStringFeature =
     signArray.length < 2
       ? lineString([signArray[0], [signArray[0][0], signArray[0][1]]])
       : lineString(signArray);
 
-  console.log("feature", lineStringFeature);
-
-  useEffect(() => {
-    const [minLng, minLat, maxLng, maxLat] = bbox(lineStringFeature);
-    console.log(minLat, minLng, maxLat, maxLng);
-
-    mapRef.current?.fitBounds(
-      [
-        [minLng, minLat],
-        [maxLng, maxLat],
-      ],
-      { padding: 40, duration: 1000 }
-    );
-  }, [mapRef, lineStringFeature]);
-  // };
+  const [minLng, minLat, maxLng, maxLat] = bbox(lineStringFeature);
 
   const signPins = useMemo(
     () =>
@@ -114,15 +91,14 @@ export default function Map({ location, signs, messageType }: MapProps) {
 
   return (
     <MapGL
-      ref={mapRef}
       initialViewState={{
         latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
         longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
         zoom: DEFAULT_MAP_PAN_ZOOM.zoom,
+        bounds: [minLng, minLat, maxLng, maxLat],
       }}
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
-      // onClick={onClick}
     >
       {/* <Marker
         longitude={mapLatLon.longitude}

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -96,7 +96,66 @@ export default function Map({ location, signs, messageType }: MapProps) {
         <Marker latitude={location[0]} longitude={location[1]} />
       )} */}
 
+      {popupInfo && (
+        <Popup
+          anchor="top"
+          longitude={Number(popupInfo.lng)}
+          latitude={Number(popupInfo.lat)}
+          onClose={() => setPopupInfo(null)}
+          offset={[0, -20]}
+        >
+          <div>
+            <span>
+              <a
+                href={`https://atd.knack.com/signs-markings#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
+                  popupInfo.id
+                }`}
+                // ensure it doesn't open in the iframe
+                target="_top"
+              >
+                Location Detail Page
+              </a>
+            </span>
+            <br />
+            <span>Spatial ID: {popupInfo.spatialId}</span>
+            <br />
+            <span>Latitude: {popupInfo.lat}</span>
+            <br />
+            <span>Longitude: {popupInfo.lng}</span>
+          </div>
+        </Popup>
+      )}
+
       <GeocoderControl position="top-left" marker={true} />
     </MapGL>
   );
 }
+
+/*
+                <Popup
+                  key={activeSign.id}
+                  coordinates={[activeSign.lng, activeSign.lat]}
+                  onClick={this.closePopup}
+                  offset={{ bottom: [0, -40] }}
+                >
+                  <div className="container popup">
+                    <span>
+                      <a
+                        href={`https://atd.knack.com/signs-markings#work-order-signs/view-work-orders-details-sign/${workOrderId}/view-work-order-signs-location-details/${
+                          activeSign.id
+                        }`}
+                        target="_top"
+                      >
+                        Location Detail Page
+                      </a>
+                    </span>
+                    <br />
+                    <span>Spatial ID: {activeSign.spatialId}</span>
+                    <br />
+                    <span>Latitude: {activeSign.lat}</span>
+                    <br />
+                    <span>Longitude: {activeSign.lng}</span>
+                  </div>
+                </Popup>
+ *
+ */

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -1,6 +1,17 @@
 "use client";
-import { useCallback, useState, useMemo } from "react";
-import MapGL, { Marker, ViewStateChangeEvent } from "react-map-gl/mapbox";
+import {
+  useCallback,
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  RefObject,
+} from "react";
+import MapGL, {
+  MapRef,
+  Marker,
+  ViewStateChangeEvent,
+} from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
 import SignPopup from "./SignPopup";
 import { MapProps, LatLon, Sign } from "@/types/map";
@@ -12,6 +23,7 @@ import {
 } from "@/config/map";
 
 export default function Map({ location, signs, messageType }: MapProps) {
+  const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
   const onDrag = useCallback((event: ViewStateChangeEvent) => {
     // truncate values to our preferred precision
@@ -60,8 +72,17 @@ export default function Map({ location, signs, messageType }: MapProps) {
     [signs]
   );
 
+  useEffect(() => {
+    console.log(mapRef.current);
+    if (!mapRef?.current || !bounds) {
+      return;
+    }
+    mapRef.current.fitBounds(bounds);
+  }, [bounds]);
+
   return (
     <MapGL
+      ref={mapRef}
       initialViewState={{
         latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
         longitude: DEFAULT_MAP_PAN_ZOOM.longitude,

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -33,7 +33,7 @@ export interface Sign {
 
 export default function Map({ location, signs, messageType }: MapProps) {
   console.log(signs);
-  const [popupInfo, setPopupInfo] = useState(null);
+  const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
   const onDrag = useCallback((event: ViewStateChangeEvent) => {
     // truncate values to our preferred precision
     const latitude = +event.viewState.latitude.toFixed(
@@ -61,7 +61,7 @@ export default function Map({ location, signs, messageType }: MapProps) {
 
   const signPins = useMemo(
     () =>
-      signs.map((sign) => (
+      signs.map((sign: Sign) => (
         <Marker
           key={`marker-${sign.id}`}
           longitude={sign.lng}

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -17,7 +17,7 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
       offset={[0, -20]}
     >
       <ul className="list-unstyled m-0">
-        {!popupInfo.locationDetailPage && (
+        {!popupInfo.isLocationDetailPage && (
           <li>
             <a
             // TODO: update to prod url when testing is completed

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -1,5 +1,6 @@
 import { Popup } from "react-map-gl/mapbox";
 import { Sign } from "@/types/map";
+import { KNACK_APP_URL } from "@/config/map";
 
 interface SignPopupProps {
   popupInfo: Sign;
@@ -20,8 +21,7 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
         {!popupInfo.isLocationDetailPage && (
           <li>
             <a
-            // TODO: update to prod url when testing is completed
-              href={`https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
+              href={`${KNACK_APP_URL}#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
                 popupInfo.id
               }`}
               // ensure it doesn't open in the iframe

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -3,7 +3,7 @@ import { Sign } from "@/components/Map";
 
 interface SignPopupProps {
   popupInfo: Sign;
-  setPopupInfo: React.Dispatch<React.SetStateAction<null>>;
+  setPopupInfo: React.Dispatch<React.SetStateAction<Sign | null>>;
 }
 
 export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -16,23 +16,24 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
       onClose={() => setPopupInfo(null)}
       offset={[0, -20]}
     >
-      <div>
-        <a
-          href={`https://atd.knack.com/signs-markings#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
-            popupInfo.id
-          }`}
-          // ensure it doesn't open in the iframe
-          target="_top"
-        >
-          Location Detail Page
-        </a>
-        <br />
-        <span>Spatial ID: {popupInfo.spatialId}</span>
-        <br />
-        <span>Latitude: {popupInfo.lat}</span>
-        <br />
-        <span>Longitude: {popupInfo.lng}</span>
-      </div>
+      <ul className="list-unstyled m-0">
+        {!popupInfo.locationDetailPage && (
+          <li>
+            <a
+              href={`https://atd.knack.com/signs-markings#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
+                popupInfo.id
+              }`}
+              // ensure it doesn't open in the iframe
+              target="_top"
+            >
+              Location Detail Page
+            </a>
+          </li>
+        )}
+        <li>Spatial ID: {popupInfo.spatialId}</li>
+        <li>Latitude: {popupInfo.lat}</li>
+        <li>Longitude: {popupInfo.lng}</li>
+      </ul>
     </Popup>
   );
 }

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -1,5 +1,5 @@
 import { Popup } from "react-map-gl/mapbox";
-import { Sign } from "@/types/map"
+import { Sign } from "@/types/map";
 
 interface SignPopupProps {
   popupInfo: Sign;

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -20,7 +20,8 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
         {!popupInfo.locationDetailPage && (
           <li>
             <a
-              href={`https://atd.knack.com/signs-markings#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
+            // TODO: update to prod url when testing is completed
+              href={`https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
                 popupInfo.id
               }`}
               // ensure it doesn't open in the iframe

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -1,5 +1,5 @@
 import { Popup } from "react-map-gl/mapbox";
-import { Sign } from "@/components/Map";
+import { Sign } from "@/types/map"
 
 interface SignPopupProps {
   popupInfo: Sign;

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -1,0 +1,38 @@
+import { Popup } from "react-map-gl/mapbox";
+import { Sign } from "@/components/Map";
+
+interface SignPopupProps {
+  popupInfo: Sign;
+  setPopupInfo: React.Dispatch<React.SetStateAction<null>>;
+}
+
+export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
+  // prod has the font as bold, do we keep?
+  return (
+    <Popup
+      anchor="top"
+      longitude={popupInfo.lng}
+      latitude={popupInfo.lat}
+      onClose={() => setPopupInfo(null)}
+      offset={[0, -20]}
+    >
+      <div>
+        <a
+          href={`https://atd.knack.com/signs-markings#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
+            popupInfo.id
+          }`}
+          // ensure it doesn't open in the iframe
+          target="_top"
+        >
+          Location Detail Page
+        </a>
+        <br />
+        <span>Spatial ID: {popupInfo.spatialId}</span>
+        <br />
+        <span>Latitude: {popupInfo.lat}</span>
+        <br />
+        <span>Longitude: {popupInfo.lng}</span>
+      </div>
+    </Popup>
+  );
+}

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -29,7 +29,6 @@ export const DEFAULT_MAP_PARAMS = {
   boxZoom: false,
   mapboxAccessToken: MAPBOX_TOKEN,
   maxBounds: MAP_MAX_BOUNDS,
-  maxZoom: 20,
   mapStyle: "mapbox://styles/mapbox/satellite-streets-v11",
 };
 

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -24,7 +24,6 @@ export const DEFAULT_MAP_PARAMS = {
   boxZoom: false,
   mapboxAccessToken: MAPBOX_TOKEN,
   maxBounds: MAP_MAX_BOUNDS,
-  maxZoom: 19,
   mapStyle: "mapbox://styles/mapbox/satellite-streets-v11",
 };
 

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -24,6 +24,7 @@ export const DEFAULT_MAP_PARAMS = {
   boxZoom: false,
   mapboxAccessToken: MAPBOX_TOKEN,
   maxBounds: MAP_MAX_BOUNDS,
+  maxZoom: 19,
   mapStyle: "mapbox://styles/mapbox/satellite-streets-v11",
 };
 

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -24,6 +24,7 @@ export const DEFAULT_MAP_PARAMS = {
   boxZoom: false,
   mapboxAccessToken: MAPBOX_TOKEN,
   maxBounds: MAP_MAX_BOUNDS,
+  maxZoom: 20,
   mapStyle: "mapbox://styles/mapbox/satellite-streets-v11",
 };
 

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -5,6 +5,11 @@ import "mapbox-gl/dist/mapbox-gl.css";
 // const NEARMAP_KEY = process.env.NEXT_PUBLIC_NEARMAP_KEY;
 const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
 
+
+// TODO: update to prod url when testing is completed
+// export const KNACK_APP_URL = 'http://atd.knack.com/signs-markings'
+export const KNACK_APP_URL = 'https://atd.knack.com/test-30-may-2024-signs-and-markings-operations';
+
 export const MAP_COORDINATE_PRECISION = 8;
 
 export const DEFAULT_MAP_PAN_ZOOM = {

--- a/signs-work-order-map/package-lock.json
+++ b/signs-work-order-map/package-lock.json
@@ -969,6 +969,47 @@
         "node": ">=10"
       }
     },
+    "node_modules/@turf/bbox": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.2.0.tgz",
+      "integrity": "sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
+      "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",

--- a/signs-work-order-map/package-lock.json
+++ b/signs-work-order-map/package-lock.json
@@ -12,9 +12,11 @@
         "@netlify/plugin-nextjs": "^5.10.7",
         "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
         "@types/mapbox-gl": "^3.4.1",
+        "bootstrap": "^5.3.6",
         "mapbox-gl": "^3.10.0",
         "next": "15.2.4",
         "react": "^19.0.0",
+        "react-bootstrap": "^2.10.10",
         "react-dom": "^19.0.0",
         "react-map-gl": "^8.0.1"
       },
@@ -49,6 +51,15 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
+      "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -836,6 +847,84 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@popperjs/core": "^2.11.8",
+        "@react-aria/ssr": "^3.5.0",
+        "@restart/hooks": "^0.5.0",
+        "@types/warning": "^3.0.3",
+        "dequal": "^2.0.3",
+        "dom-helpers": "^5.2.0",
+        "uncontrollable": "^8.0.4",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/@restart/hooks": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/uncontrollable": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.14.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -998,11 +1087,16 @@
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.0.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
       "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1016,6 +1110,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -1034,6 +1137,12 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.28.0",
@@ -1645,6 +1754,25 @@
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
+    "node_modules/bootstrap": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1849,6 +1977,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1952,7 +2086,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2129,6 +2262,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2150,6 +2292,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -3431,6 +3583,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -4068,7 +4229,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4393,7 +4553,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4758,12 +4917,24 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/protocol-buffers-schema": {
@@ -4835,6 +5006,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-bootstrap": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
+      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "@restart/hooks": "^0.4.9",
+        "@restart/ui": "^1.9.4",
+        "@types/prop-types": "^15.7.12",
+        "@types/react-transition-group": "^4.4.6",
+        "classnames": "^2.3.2",
+        "dom-helpers": "^5.2.1",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "prop-types-extra": "^1.1.0",
+        "react-transition-group": "^4.4.5",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.8",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
@@ -4851,7 +5053,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
     },
     "node_modules/react-map-gl": {
@@ -4876,6 +5083,22 @@
         "maplibre-gl": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-pkg": {
@@ -6081,6 +6304,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -6156,6 +6394,15 @@
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
         "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/signs-work-order-map/package-lock.json
+++ b/signs-work-order-map/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.0.3",
         "@netlify/plugin-nextjs": "^5.10.7",
+        "@turf/bbox": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
         "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
         "@types/mapbox-gl": "^3.4.1",
         "bootstrap": "^5.3.5",

--- a/signs-work-order-map/package-lock.json
+++ b/signs-work-order-map/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-config-next": "15.2.4",
         "eslint-config-prettier": "^10.1.1",
         "prettier": "^3.5.3",
-        "sass": "^1.86.1",
+        "sass": "^1.86.3",
         "typescript": "^5"
       }
     },
@@ -58,19 +58,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-<<<<<<< HEAD
       "version": "7.27.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
       "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
       "license": "MIT",
-=======
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
->>>>>>> 22245-iframe-messages
       "engines": {
         "node": ">=6.9.0"
       }
@@ -870,10 +861,7 @@
       "version": "3.9.8",
       "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
       "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
-<<<<<<< HEAD
       "license": "Apache-2.0",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -888,10 +876,7 @@
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
       "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "dequal": "^2.0.3"
       },
@@ -903,10 +888,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
       "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@popperjs/core": "^2.11.8",
@@ -927,10 +909,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
       "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "dequal": "^2.0.3"
       },
@@ -942,10 +921,7 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
       "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "peerDependencies": {
         "react": ">=16.14.0"
       }
@@ -1115,12 +1091,8 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-<<<<<<< HEAD
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
       "license": "MIT"
-=======
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
->>>>>>> 22245-iframe-messages
     },
     "node_modules/@types/react": {
       "version": "19.0.12",
@@ -1145,10 +1117,7 @@
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "peerDependencies": {
         "@types/react": "*"
       }
@@ -1173,12 +1142,8 @@
     "node_modules/@types/warning": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-<<<<<<< HEAD
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
       "license": "MIT"
-=======
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
->>>>>>> 22245-iframe-messages
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.28.0",
@@ -1791,15 +1756,9 @@
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "node_modules/bootstrap": {
-<<<<<<< HEAD
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
       "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
-=======
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.5.tgz",
-      "integrity": "sha512-ct1CHKtiobRimyGzmsSldEtM03E8fcEX4Tb3dGXz1V8faRwM50+vfHwTzOxB3IlKO7m+9vTH3s/3C6T2EAPeTA==",
->>>>>>> 22245-iframe-messages
       "funding": [
         {
           "type": "github",
@@ -1810,10 +1769,7 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -2025,12 +1981,8 @@
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-<<<<<<< HEAD
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
-=======
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
->>>>>>> 22245-iframe-messages
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -2315,10 +2267,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "engines": {
         "node": ">=6"
       }
@@ -2350,10 +2299,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -3642,10 +3588,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -4986,10 +4929,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
       "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
@@ -5068,16 +5008,10 @@
       }
     },
     "node_modules/react-bootstrap": {
-<<<<<<< HEAD
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
       "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
       "license": "MIT",
-=======
-      "version": "2.10.9",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.9.tgz",
-      "integrity": "sha512-TJUCuHcxdgYpOqeWmRApM/Dy0+hVsxNRFvq2aRFQuxhNi/+ivOxC5OdWIeHS3agxvzJ4Ev4nDw2ZdBl9ymd/JQ==",
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "@babel/runtime": "^7.24.7",
         "@restart/hooks": "^0.4.9",
@@ -5117,9 +5051,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
-      "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.57.0.tgz",
+      "integrity": "sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -5136,21 +5070,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-<<<<<<< HEAD
       "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-=======
->>>>>>> 22245-iframe-messages
       "license": "MIT"
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-map-gl": {
       "version": "8.0.1",
@@ -5180,10 +5106,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-<<<<<<< HEAD
       "license": "BSD-3-Clause",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -5373,11 +5296,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -6407,10 +6325,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
       "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "@babel/runtime": "^7.6.3",
         "@types/react": ">=16.9.11",
@@ -6502,10 +6417,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-<<<<<<< HEAD
       "license": "MIT",
-=======
->>>>>>> 22245-iframe-messages
       "dependencies": {
         "loose-envify": "^1.0.0"
       }

--- a/signs-work-order-map/package.json
+++ b/signs-work-order-map/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@mapbox/mapbox-gl-geocoder": "^5.0.3",
     "@netlify/plugin-nextjs": "^5.10.7",
+    "@turf/bbox": "^7.2.0",
+    "@turf/helpers": "^7.2.0",
     "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
     "@types/mapbox-gl": "^3.4.1",
     "bootstrap": "^5.3.5",

--- a/signs-work-order-map/package.json
+++ b/signs-work-order-map/package.json
@@ -13,9 +13,11 @@
     "@netlify/plugin-nextjs": "^5.10.7",
     "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
     "@types/mapbox-gl": "^3.4.1",
+    "bootstrap": "^5.3.6",
     "mapbox-gl": "^3.10.0",
     "next": "15.2.4",
     "react": "^19.0.0",
+    "react-bootstrap": "^2.10.10",
     "react-dom": "^19.0.0",
     "react-map-gl": "^8.0.1"
   },

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -4,7 +4,11 @@ export interface LatLon {
 }
 
 export interface MapProps {
-  location: [number, number] | undefined;
+  // update the location
+  location: {
+    longitude: number | undefined;
+    latitude: number | undefined;
+  };
   signs: any;
   messageType: string | undefined; // refine this more to only be one of the specific messages?
 }
@@ -14,46 +18,84 @@ export interface Sign {
   lng: number;
   lat: number;
   spatialId: number;
-  workOrderId?: string;
+  workOrderId: string;
 }
 
-export interface KnackRecord { 
-    field_3297: number;
-      field_3297_raw: number;
-      /** address */
-      field_3300: string,
-      field_3300_raw: {
-        city: string;
-        country: string;
-        full: string;
-        latitude: number;
-        longitude: number;
-        state: string;
-        street: string;
-        street2: string | null;
-        zip: string;
-      },
-    //   field_3301: string
-    //   field_3301_raw: [
-    //     { id: string, identifier: string },
-    //   ],
-    //   field_3302: "08/01/2019",
-    //   field_3302_raw: {
-    //     am_pm: "AM",
-    //     date: "08/01/2019",
-    //     date_formatted: "08/01/2019",
-    //     hours: "12",
-    //     iso_timestamp: "2019-08-01T00:00:00.000Z",
-    //     minutes: "00",
-    //     proper_iso_timestamp: "2019-08-01T05:00:00.000Z",
-    //     proper_unix_timestamp: 1564635600000,
-    //     time: 0,
-    //     timestamp: "08/01/2019 12:00 am",
-    //     unix_timestamp: 1564617600000,
-    //   },
-    //   field_3378: "",
-    //   field_3378_raw: "",
-    //   field_3425: 1,
-    //   field_3425_raw: 1,
-      id: string;
+export interface KnackRecord {
+  field_3297: number;
+  field_3297_raw: number;
+  /** address */
+  field_3300: string;
+  field_3300_raw: {
+    city: string;
+    country: string;
+    full: string;
+    latitude: number;
+    longitude: number;
+    state: string;
+    street: string;
+    street2: string | null;
+    zip: string;
+  };
+  //   field_3301: string
+  //   field_3301_raw: [
+  //     { id: string, identifier: string },
+  //   ],
+  //   field_3302: "08/01/2019",
+  //   field_3302_raw: {
+  //     am_pm: "AM",
+  //     date: "08/01/2019",
+  //     date_formatted: "08/01/2019",
+  //     hours: "12",
+  //     iso_timestamp: "2019-08-01T00:00:00.000Z",
+  //     minutes: "00",
+  //     proper_iso_timestamp: "2019-08-01T05:00:00.000Z",
+  //     proper_unix_timestamp: 1564635600000,
+  //     time: 0,
+  //     timestamp: "08/01/2019 12:00 am",
+  //     unix_timestamp: 1564617600000,
+  //   },
+  //   field_3378: "",
+  //   field_3378_raw: "",
+  //   field_3425: 1,
+  //   field_3425_raw: 1,
+  id: string;
 }
+
+export type KnackToIFrameMessage =
+  | {
+      message: "KNACK_LOCATION_DETAILS";
+      payload: {
+        records: KnackRecord[];
+        location: {
+          longitude: number | undefined;
+          latitude: number | undefined;
+        };
+        workOrderId: string;
+      };
+    }
+  | {
+      message: "WORK_ORDER_SIGNS";
+      payload: {
+        records: KnackRecord[];
+        workOrderId: string;
+      };
+    }
+  | {
+      message: "EDIT_LOCATION";
+      payload: {
+        location: {
+          longitude: number | undefined;
+          latitude: number | undefined;
+        };
+      };
+    }
+  | {
+      message: "KNACK_GEOLOCATION";
+      payload: {
+        geolocation: {
+          latitude: number | undefined; // maybe not undefined?
+          longitude: number | undefined;
+        };
+      };
+    };

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -40,29 +40,29 @@ export interface KnackRecord {
     zip: string;
   };
   /** created date */
-  field_3302: string;
+  field_3302?: string;
   /** created date raw format */
-  field_3302_raw: {
-    am_pm: "AM" | "PM";
-    date: string;
-    date_formatted: string;
-    hours: string;
-    iso_timestamp: string;
-    minutes: string;
-    proper_iso_timestamp: string;
-    proper_unix_timestamp: number;
-    time: number;
-    timestamp: string;
-    unix_timestamp: number;
+  field_3302_raw?: {
+    am_pm?: "AM" | "PM";
+    date?: string;
+    date_formatted?: string;
+    hours?: string;
+    iso_timestamp?: string;
+    minutes?: string;
+    proper_iso_timestamp?: string;
+    proper_unix_timestamp?: number;
+    time?: number;
+    timestamp?: string;
+    unix_timestamp?: number;
   };
   /** photo */
-  field_3378: string;
+  field_3378?: string;
   /** photo raw format */
-  field_3378_raw: string;
+  field_3378_raw?: string;
   /** count of assets  */
-  field_3425: number;
+  field_3425?: number;
   /** count of assets raw format*/
-  field_3425_raw: number;
+  field_3425_raw?: number;
   /** knack record id */
   id: string;
 }

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -19,6 +19,7 @@ export interface Sign {
   lat: number;
   spatialId: number;
   workOrderId: string;
+  locationDetailPage: boolean;
 }
 
 export interface KnackRecord {
@@ -72,6 +73,7 @@ export type KnackToIFrameMessage =
           latitude: number | undefined;
         };
         workOrderId: string;
+        locationRecordId: string;
       };
     }
   | {

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -33,10 +33,9 @@ export interface KnackRecord {
         street2: string | null;
         zip: string;
       },
-    //   field_3301:
-    //     '<span class="5d13ae66d3186524eaea0b20">Librado Murrieta</span>',
+    //   field_3301: string
     //   field_3301_raw: [
-    //     { id: "5d13ae66d3186524eaea0b20", identifier: "Librado Murrieta" },
+    //     { id: string, identifier: string },
     //   ],
     //   field_3302: "08/01/2019",
     //   field_3302_raw: {

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -21,10 +21,13 @@ export interface Sign {
 }
 
 export interface KnackRecord {
+  /** spatial id */
   field_3297: number;
+  /** spatial id raw format */
   field_3297_raw: number;
-  /** address */
+  /** address in string form */
   field_3300: string;
+  /** address raw format  */
   field_3300_raw: {
     city: string;
     country: string;
@@ -36,28 +39,31 @@ export interface KnackRecord {
     street2: string | null;
     zip: string;
   };
-  //   field_3301: string
-  //   field_3301_raw: [
-  //     { id: string, identifier: string },
-  //   ],
-  //   field_3302: "08/01/2019",
-  //   field_3302_raw: {
-  //     am_pm: "AM",
-  //     date: "08/01/2019",
-  //     date_formatted: "08/01/2019",
-  //     hours: "12",
-  //     iso_timestamp: "2019-08-01T00:00:00.000Z",
-  //     minutes: "00",
-  //     proper_iso_timestamp: "2019-08-01T05:00:00.000Z",
-  //     proper_unix_timestamp: 1564635600000,
-  //     time: 0,
-  //     timestamp: "08/01/2019 12:00 am",
-  //     unix_timestamp: 1564617600000,
-  //   },
-  //   field_3378: "",
-  //   field_3378_raw: "",
-  //   field_3425: 1,
-  //   field_3425_raw: 1,
+  /** created date */
+  field_3302: string;
+  /** created date raw format */
+  field_3302_raw: {
+    am_pm: "AM" | "PM";
+    date: string;
+    date_formatted: string;
+    hours: string;
+    iso_timestamp: string;
+    minutes: string;
+    proper_iso_timestamp: string;
+    proper_unix_timestamp: number;
+    time: number;
+    timestamp: string;
+    unix_timestamp: number;
+  };
+  /** photo */
+  field_3378: string;
+  /** photo raw format */
+  field_3378_raw: string;
+  /** count of assets  */
+  field_3425: number;
+  /** count of assets raw format*/
+  field_3425_raw: number;
+  /** knack record id */
   id: string;
 }
 
@@ -94,7 +100,7 @@ export type KnackToIFrameMessage =
       message: "KNACK_GEOLOCATION";
       payload: {
         geolocation: {
-          latitude: number | undefined; // maybe not undefined?
+          latitude: number | undefined;
           longitude: number | undefined;
         };
       };

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -17,7 +17,7 @@ export interface Sign {
   lat: number;
   spatialId: number;
   workOrderId: string;
-  locationDetailPage: boolean;
+  isLocationDetailPage: boolean;
 }
 
 export interface KnackRecord {

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -4,13 +4,11 @@ export interface LatLon {
 }
 
 export interface MapProps {
-  // update the location
   location: {
     longitude: number | undefined;
     latitude: number | undefined;
   };
-  signs: any;
-  messageType: string | undefined; // refine this more to only be one of the specific messages?
+  signs: Sign[];
 }
 
 export interface Sign {

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -1,6 +1,6 @@
 export interface LatLon {
-  latitude: number;
-  longitude: number;
+  latitude: number | undefined;
+  longitude: number | undefined;
 }
 
 export interface MapProps {

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -1,0 +1,60 @@
+export interface LatLon {
+  latitude: number;
+  longitude: number;
+}
+
+export interface MapProps {
+  location: [number, number] | undefined;
+  signs: any;
+  messageType: string | undefined; // refine this more to only be one of the specific messages?
+}
+
+export interface Sign {
+  id: string;
+  lng: number;
+  lat: number;
+  spatialId: number;
+  workOrderId?: string;
+}
+
+export interface KnackRecord { 
+    field_3297: number;
+      field_3297_raw: number;
+      /** address */
+      field_3300: string,
+      field_3300_raw: {
+        city: string;
+        country: string;
+        full: string;
+        latitude: number;
+        longitude: number;
+        state: string;
+        street: string;
+        street2: string | null;
+        zip: string;
+      },
+    //   field_3301:
+    //     '<span class="5d13ae66d3186524eaea0b20">Librado Murrieta</span>',
+    //   field_3301_raw: [
+    //     { id: "5d13ae66d3186524eaea0b20", identifier: "Librado Murrieta" },
+    //   ],
+    //   field_3302: "08/01/2019",
+    //   field_3302_raw: {
+    //     am_pm: "AM",
+    //     date: "08/01/2019",
+    //     date_formatted: "08/01/2019",
+    //     hours: "12",
+    //     iso_timestamp: "2019-08-01T00:00:00.000Z",
+    //     minutes: "00",
+    //     proper_iso_timestamp: "2019-08-01T05:00:00.000Z",
+    //     proper_unix_timestamp: 1564635600000,
+    //     time: 0,
+    //     timestamp: "08/01/2019 12:00 am",
+    //     unix_timestamp: 1564617600000,
+    //   },
+    //   field_3378: "",
+    //   field_3378_raw: "",
+    //   field_3425: 1,
+    //   field_3425_raw: 1,
+      id: string;
+}

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -19,6 +19,8 @@ export function useIFrameMessenger() {
       ) {
         return;
       }
+
+      console.log(event.data)
       const data = JSON.parse(event.data);
       setMessage(data);
     };

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -3,8 +3,10 @@ import { useEffect, useState } from "react";
 
 type MessageToIFrame = {
   message: string;
-  records: [];
-  location: [number, number];
+  payload: {
+    records: [];
+    location: [number, number];
+  };
 };
 
 export function useIFrameMessenger() {
@@ -20,7 +22,7 @@ export function useIFrameMessenger() {
         return;
       }
 
-      console.log(event.data)
+      console.log(event.data);
       const data = JSON.parse(event?.data);
       setMessage(data);
     };

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -1,14 +1,14 @@
 "use client";
 import { useEffect, useState } from "react";
 
-type MessageToIframe = {
+type MessageToIFrame = {
   message: string;
   records: [];
   location: [number, number];
 };
 
 export function useIFrameMessenger() {
-  const [message, setMessage] = useState<MessageToIframe | null>(null);
+  const [message, setMessage] = useState<MessageToIFrame | null>(null);
 
   useEffect(() => {
     const consoleMessage = (event: MessageEvent) => {

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -2,21 +2,16 @@
 import { useEffect, useState } from "react";
 import { KnackToIFrameMessage } from "@/types/map";
 
-
 export function useIFrameMessenger() {
   const [message, setMessage] = useState<KnackToIFrameMessage | null>(null);
 
   useEffect(() => {
     const consoleMessage = (event: MessageEvent) => {
-      if (
-        event.data.source === "react-devtools-content-script" ||
-        event.data.source === "react-devtools-bridge" ||
-        event.data.source === "react-devtools-backend-manager"
-      ) {
+      if (event.origin !== "https://atd.knack.com") {
         return;
       }
 
-      const data = JSON.parse(event?.data);
+      const data: KnackToIFrameMessage = JSON.parse(event?.data);
       setMessage(data);
     };
     window.addEventListener("message", consoleMessage);

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -1,16 +1,10 @@
 "use client";
 import { useEffect, useState } from "react";
+import { KnackToIFrameMessage } from "@/types/map";
 
-type MessageToIFrame = {
-  message: string;
-  payload: {
-    records: [];
-    location: [number, number];
-  };
-};
 
 export function useIFrameMessenger() {
-  const [message, setMessage] = useState<MessageToIFrame | null>(null);
+  const [message, setMessage] = useState<KnackToIFrameMessage | null>(null);
 
   useEffect(() => {
     const consoleMessage = (event: MessageEvent) => {

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -21,7 +21,7 @@ export function useIFrameMessenger() {
       }
 
       console.log(event.data)
-      const data = JSON.parse(event.data);
+      const data = JSON.parse(event?.data);
       setMessage(data);
     };
     window.addEventListener("message", consoleMessage);

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -16,7 +16,6 @@ export function useIFrameMessenger() {
         return;
       }
 
-      console.log(event.data);
       const data = JSON.parse(event?.data);
       setMessage(data);
     };

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
-import { Sign } from "@/types/map";
+import { Sign, KnackToIFrameMessage } from "@/types/map";
 import { LngLatBoundsLike } from "mapbox-gl";
 
 /**
- *
+ * Takes array of Signs and if signs exist, returns bounding box for signs
  * @param signs
  * @returns
  */
@@ -14,13 +14,42 @@ export const formatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
     if (signs.length === 0) {
       return undefined;
     }
-    const signArray = signs.map((sign: Sign) => [sign.lng, sign.lat]);
+    const signLatLonArray = signs.map((sign: Sign) => [sign.lng, sign.lat]);
 
     const lineStringFeature =
-      signArray.length < 2
-        ? lineString([signArray[0], [signArray[0][0], signArray[0][1]]])
-        : lineString(signArray);
+      // if there is only one sign in the array, create the linestring for the bounding box using the one sign
+      signLatLonArray.length < 2
+        ? lineString([
+            signLatLonArray[0],
+            [signLatLonArray[0][0], signLatLonArray[0][1]],
+          ])
+        : lineString(signLatLonArray);
 
     const [minLng, minLat, maxLng, maxLat] = bbox(lineStringFeature);
     return [minLng, minLat, maxLng, maxLat];
   }, [signs]);
+
+/**
+ * Function that takes data from knack app and depending on message type, returns array of signs or empty array
+ * @param knackPayload - message from Knack via IFrameMessage
+ * @returns Array of Signs or empty array if no sign data
+ */
+export const formatSignsRecords = (
+  knackPayload: KnackToIFrameMessage | null
+): Sign[] =>
+  useMemo(() => {
+    if (!knackPayload) return [];
+    if (
+      knackPayload?.message === "EDIT_LOCATION" ||
+      knackPayload?.message === "KNACK_GEOLOCATION"
+    ) {
+      return [];
+    }
+    return knackPayload.payload.records.map((sign) => ({
+      id: sign.id,
+      lat: sign.field_3300_raw.latitude,
+      lng: sign.field_3300_raw.longitude,
+      spatialId: sign.field_3297,
+      workOrderId: knackPayload.payload.workOrderId,
+    }));
+  }, [knackPayload]);

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,0 +1,25 @@
+import bbox from "@turf/bbox";
+import { lineString } from "@turf/helpers";
+import { Sign } from "@/types/map";
+import { LngLatBoundsLike } from "mapbox-gl";
+
+
+/**
+ *
+ * @param signs
+ * @returns
+ */
+export const formatBounds = (signs: Sign[]) : undefined | LngLatBoundsLike => {
+  if (signs.length === 0) {
+    return undefined;
+  }
+  const signArray = signs.map((sign: Sign) => [sign.lng, sign.lat]);
+
+  const lineStringFeature =
+    signArray.length < 2
+      ? lineString([signArray[0], [signArray[0][0], signArray[0][1]]])
+      : lineString(signArray);
+
+  const [minLng, minLat, maxLng, maxLat] = bbox(lineStringFeature);
+  return [minLng, minLat, maxLng, maxLat];
+};

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
-import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
 import { LngLatBoundsLike } from "mapbox-gl";
+import { Marker } from "react-map-gl/mapbox";
+import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
 
 /**
  * Takes array of Signs and if signs exist, returns bounding box for signs
@@ -86,3 +87,33 @@ export const formatLocation = (
       latitude: knackPayload.payload.location.latitude,
     };
   }, [knackPayload]);
+
+/**
+ * Takes array of Signs and if signs exist, returns bounding box for signs
+ * @param signs
+ * @returns
+ */
+export const createSignPins = (
+  signs: Sign[],
+  setPopupInfo: React.Dispatch<React.SetStateAction<Sign | null>>
+) =>
+  useMemo(
+    () =>
+      signs.map((sign: Sign) => (
+        <Marker
+          key={`marker-${sign.id}`}
+          longitude={sign.lng}
+          latitude={sign.lat}
+          anchor="bottom"
+          color={sign.locationDetailPage ? "red" : undefined}
+          onClick={(e) => {
+            // If we let the click event propagates to the map, it will immediately close the popup
+            // with `closeOnClick: true`
+            e.originalEvent.stopPropagation();
+            console.log(sign);
+            setPopupInfo(sign);
+          }}
+        />
+      )),
+    [signs, setPopupInfo]
+  );

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,25 +1,26 @@
+import { useMemo } from "react";
 import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
 import { Sign } from "@/types/map";
 import { LngLatBoundsLike } from "mapbox-gl";
-
 
 /**
  *
  * @param signs
  * @returns
  */
-export const formatBounds = (signs: Sign[]) : undefined | LngLatBoundsLike => {
-  if (signs.length === 0) {
-    return undefined;
-  }
-  const signArray = signs.map((sign: Sign) => [sign.lng, sign.lat]);
+export const formatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
+  useMemo(() => {
+    if (signs.length === 0) {
+      return undefined;
+    }
+    const signArray = signs.map((sign: Sign) => [sign.lng, sign.lat]);
 
-  const lineStringFeature =
-    signArray.length < 2
-      ? lineString([signArray[0], [signArray[0][0], signArray[0][1]]])
-      : lineString(signArray);
+    const lineStringFeature =
+      signArray.length < 2
+        ? lineString([signArray[0], [signArray[0][0], signArray[0][1]]])
+        : lineString(signArray);
 
-  const [minLng, minLat, maxLng, maxLat] = bbox(lineStringFeature);
-  return [minLng, minLat, maxLng, maxLat];
-};
+    const [minLng, minLat, maxLng, maxLat] = bbox(lineStringFeature);
+    return [minLng, minLat, maxLng, maxLat];
+  }, [signs]);

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -8,7 +8,7 @@ import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
 /**
  * Takes array of Signs and if signs exist, returns bounding box for signs
  * @param signs
- * @returns
+ * @returns bbox extent in [minX, minY, maxX, maxY] order or undefined
  */
 export const formatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
   useMemo(() => {
@@ -65,7 +65,7 @@ export const formatSignsRecords = (
 /**
  * Function that takes data from knack app and depending on message type, returns location
  * @param knackPayload - message from Knack via IFrameMessage
- * @returns
+ * @returns LatLon object
  */
 export const formatLocation = (
   knackPayload: KnackToIFrameMessage | null
@@ -89,9 +89,11 @@ export const formatLocation = (
   }, [knackPayload]);
 
 /**
- * Takes array of Signs and if signs exist, returns bounding box for signs
+ * Takes array of Signs and returns array of map markers, one marker per sign
+ * If the sign id matches the location detail page id, render the marker as red
+ * otherwise, use default color
  * @param signs
- * @returns
+ * @returns Array of Map Markers
  */
 export const createSignPins = (
   signs: Sign[],

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
-import { Sign, KnackToIFrameMessage } from "@/types/map";
+import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
 import { LngLatBoundsLike } from "mapbox-gl";
 
 /**
@@ -52,4 +52,30 @@ export const formatSignsRecords = (
       spatialId: sign.field_3297,
       workOrderId: knackPayload.payload.workOrderId,
     }));
+  }, [knackPayload]);
+
+/**
+ * Function that takes data from knack app and depending on message type, returns location
+ * @param knackPayload - message from Knack via IFrameMessage
+ * @returns
+ */
+export const formatLocation = (
+  knackPayload: KnackToIFrameMessage | null
+): LatLon =>
+  useMemo(() => {
+    if (!knackPayload || knackPayload?.message === "WORK_ORDER_SIGNS") {
+      return { longitude: undefined, latitude: undefined };
+    }
+
+    if (knackPayload.message === "KNACK_GEOLOCATION") {
+      return {
+        longitude: knackPayload.payload.geolocation.longitude,
+        latitude: knackPayload.payload.geolocation.latitude,
+      };
+    }
+
+    return {
+      longitude: knackPayload.payload.location.longitude,
+      latitude: knackPayload.payload.location.latitude,
+    };
   }, [knackPayload]);

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -58,7 +58,7 @@ export const useFormatSignsRecords = (
       lng: sign.field_3300_raw.longitude,
       spatialId: sign.field_3297,
       workOrderId: knackPayload.payload.workOrderId,
-      locationDetailPage: sign.id === locationId,
+      isLocationDetailPage: sign.id === locationId,
     }));
   }, [knackPayload]);
 
@@ -107,7 +107,7 @@ export const useCreateSignPins = (
           longitude={sign.lng}
           latitude={sign.lat}
           anchor="bottom"
-          color={sign.locationDetailPage ? "red" : undefined}
+          color={sign.isLocationDetailPage ? "red" : undefined}
           onClick={(e) => {
             // If we let the click event propagates to the map, it will immediately close the popup
             // with `closeOnClick: true`

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -101,21 +101,25 @@ export const useCreateSignPins = (
 ) =>
   useMemo(
     () =>
-      signs.map((sign: Sign) => (
-        <Marker
-          key={`marker-${sign.id}`}
-          longitude={sign.lng}
-          latitude={sign.lat}
-          anchor="bottom"
-          color={sign.isLocationDetailPage ? "red" : undefined}
-          onClick={(e) => {
-            // If we let the click event propagates to the map, it will immediately close the popup
-            // with `closeOnClick: true`
-            e.originalEvent.stopPropagation();
-            console.log(sign);
-            setPopupInfo(sign);
-          }}
-        />
-      )),
+      signs.map(
+        (sign: Sign) =>
+          sign.lat &&
+          sign.lng && (
+            <Marker
+              key={`marker-${sign.id}`}
+              longitude={sign.lng}
+              latitude={sign.lat}
+              anchor="bottom"
+              color={sign.isLocationDetailPage ? "red" : undefined}
+              onClick={(e) => {
+                // If we let the click event propagates to the map, it will immediately close the popup
+                // with `closeOnClick: true`
+                e.originalEvent.stopPropagation();
+                console.log(sign);
+                setPopupInfo(sign);
+              }}
+            />
+          )
+      ),
     [signs, setPopupInfo]
   );

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -10,7 +10,7 @@ import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
  * @param signs
  * @returns bbox extent in [minX, minY, maxX, maxY] order or undefined
  */
-export const formatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
+export const useFormatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
   useMemo(() => {
     if (signs.length === 0) {
       return undefined;
@@ -35,7 +35,7 @@ export const formatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
  * @param knackPayload - message from Knack via IFrameMessage
  * @returns Array of Signs or empty array if no sign data
  */
-export const formatSignsRecords = (
+export const useFormatSignsRecords = (
   knackPayload: KnackToIFrameMessage | null
 ): Sign[] =>
   useMemo(() => {
@@ -67,7 +67,7 @@ export const formatSignsRecords = (
  * @param knackPayload - message from Knack via IFrameMessage
  * @returns LatLon object
  */
-export const formatLocation = (
+export const useFormatLocation = (
   knackPayload: KnackToIFrameMessage | null
 ): LatLon =>
   useMemo(() => {
@@ -95,7 +95,7 @@ export const formatLocation = (
  * @param signs
  * @returns Array of Map Markers
  */
-export const createSignPins = (
+export const useCreateSignPins = (
   signs: Sign[],
   setPopupInfo: React.Dispatch<React.SetStateAction<Sign | null>>
 ) =>

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -45,12 +45,19 @@ export const formatSignsRecords = (
     ) {
       return [];
     }
+
+    const locationId =
+      knackPayload.message === "KNACK_LOCATION_DETAILS"
+        ? knackPayload?.payload?.locationRecordId
+        : null;
+
     return knackPayload.payload.records.map((sign) => ({
       id: sign.id,
       lat: sign.field_3300_raw.latitude,
       lng: sign.field_3300_raw.longitude,
       spatialId: sign.field_3297,
       workOrderId: knackPayload.payload.workOrderId,
+      locationDetailPage: sign.id === locationId,
     }));
   }, [knackPayload]);
 


### PR DESCRIPTION
Related Issue: https://github.com/cityofaustin/atd-data-tech/issues/22803

Testing instructions
https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/

sign in as a non-coa user, test-tech@austintexas.gov, the password is in 1pw under SMD test technician

Work orders have sign records if they have the status "Final Review" or "Closed"
![Screenshot 2025-06-13 at 2 00 27 PM](https://github.com/user-attachments/assets/8714bb45-3739-428d-97a7-bf80297ed4e0)

Click on a work order, when the page loads, the map should zoom to show the sign markers. A lot of the records only have one location, but [here](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/5fa5b8264416d10019334024/) is an example of a work order with multiple locations. 

Clicking on one of the markers will bring up the details popup, with a link to the location details page. Click the link to the details page. 

![Screenshot 2025-06-13 at 2 11 38 PM](https://github.com/user-attachments/assets/e95e1f03-3156-4cef-81a8-bdff285739d7)

The map should look very similar on the location details page, except for the marker color. The location that corresponds to the location detail page being viewed should have a red marker, and the popup omits the link to the location details page. 


What do you think of the popup's styling? Production has everything bolded on it (see issue for reference), do you think it should be bolder? Font bigger?

Like the previous PR, if you want to run the react app locally and test that way, you need to update the iFrameMapMessengerDev.js file in s3 to use localhost instead of the deployed site. 
Make sure it is the dev file and not the production file. 
 