### PR TITLE
Ability for map to load to current location using device location

### DIFF
--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -39,13 +39,6 @@
     };
   }
 
-  function AutozoomSendMessageToApp(message) {
-    var iframe = document.getElementById("mapIFrame").contentWindow;
-    const stringifiedMessage = JSON.stringify(message);
-    console.log("autozoom message to app ", message.message);
-    iframe.postMessage(stringifiedMessage, "*");
-  }
-
   // Start polling...
   checkReady(function ($) {
     var $viewSelector = $(myView);
@@ -65,7 +58,7 @@
      */
     function sendMessageToApp(message, iframe) {
       var stringifiedMessage = JSON.stringify(message);
-      iframe.postMessage(stringifiedMessage, "*");
+      iframe.postMessage(stringifiedMessage, nextAppUrl);
     }
 
     // Listen for lat/lon changes
@@ -231,23 +224,5 @@
       sendLocationMapMessage("view_2682");
     });
 
-    // Get the current location from browser.
-    navigator.geolocation.getCurrentPosition(function (position) {
-      // create message object for React App
-      const geolocationMessage = {
-        message: "KNACK_GEOLOCATION",
-        payload: {
-          geolocation: {
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-          },
-        },
-      };
-
-      // sends geolocation once the iframe is loaded
-      $("#mapIFrame").on("load", function () {
-        AutozoomSendMessageToApp(geolocationMessage);
-      });
-    });
   });
 })();

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -7,9 +7,9 @@
 (function () {
   var myView = window.viewIdsArray.shift(0);
 
-  const nextAppUrl =
-    "https://deploy-preview-328--nextjs-knack-signs-markings.netlify.app/";
-  // const nextAppUrl = "http://localhost:3000";
+  // const nextAppUrl =
+  //   "https://deploy-preview-328--nextjs-knack-signs-markings.netlify.app/";
+  const nextAppUrl = "http://localhost:3000";
 
   // Import jQuery into this file from CDN
   // https://stackoverflow.com/questions/34338411/how-to-import-jquery-using-es6-syntax
@@ -62,22 +62,18 @@
     }
 
     // Listen for lat/lon changes
-    // expects a message named "LAT_LON_FIELDS"
+    // expects a message named "LAT_LON_UPDATE"
     // uses lat and lng from message to populate input fields in knack
     window.addEventListener("message", function (event) {
       if (event.origin !== nextAppUrl) {
         return;
       }
       var data = event.data;
-      if (data.message === "LAT_LON_FIELDS") {
-        console.log("received message ", data);
+      if (data.message === "LAT_LON_UPDATE") {
+        console.log("knack received message ", data);
         var $latLonFields = $("#kn-input-field_3300");
-        if (!!data.lat && !!data.lng) {
-          $latLonFields.find("#latitude").val(data.lat);
-          $latLonFields.find("[name='longitude']").val(data.lng);
-        } else {
-          console.error("Payload missing complete location data ", data);
-        }
+        $latLonFields.find("#latitude").val(data.lat);
+        $latLonFields.find("[name='longitude']").val(data.lng);
       }
     });
 

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -7,9 +7,9 @@
 (function () {
   var myView = window.viewIdsArray.shift(0);
 
-  const nextAppUrl =
-    "https://deploy-preview-327--nextjs-knack-signs-markings.netlify.app/";
-  // const nextAppUrl = "http://localhost:3000";
+  // const nextAppUrl =
+  // "https://deploy-preview-327--nextjs-knack-signs-markings.netlify.app/";
+  const nextAppUrl = "http://localhost:3000";
 
   // Import jQuery into this file from CDN
   // https://stackoverflow.com/questions/34338411/how-to-import-jquery-using-es6-syntax
@@ -53,8 +53,8 @@
     // Add React app as iframe if iframe doesn't already exist
     if ($(myView + " #mapIFrame").length === 0) {
       https: $(
-        `<iframe src=${nextAppUrl} frameborder="0" scrolling="yes" id="mapIFrame" \
-        style="width: 100%;height: 523px;"></iframe>`
+        `<iframe src=${nextAppUrl} frameborder="0" allow="geolocation" scrolling="yes" \
+        id="mapIFrame" style="width: 100%;height: 523px;"></iframe>`
       ).appendTo($viewSelector);
     }
 
@@ -79,9 +79,12 @@
       if (data.message === "LAT_LON_FIELDS") {
         console.log("received message ", data);
         var $latLonFields = $("#kn-input-field_3300");
-
-        $latLonFields.find("#latitude").val(data.lat);
-        $latLonFields.find("[name='longitude']").val(data.lng);
+        if (!!data.lat && !!data.lng) {
+          $latLonFields.find("#latitude").val(data.lat);
+          $latLonFields.find("[name='longitude']").val(data.lng);
+        } else {
+          console.error("Payload missing complete location data ", data);
+        }
       }
     });
 

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -7,9 +7,9 @@
 (function () {
   var myView = window.viewIdsArray.shift(0);
 
-  // const nextAppUrl =
-  // "https://deploy-preview-327--nextjs-knack-signs-markings.netlify.app/";
-  const nextAppUrl = "http://localhost:3000";
+  const nextAppUrl =
+    "https://deploy-preview-328--nextjs-knack-signs-markings.netlify.app/";
+  // const nextAppUrl = "http://localhost:3000";
 
   // Import jQuery into this file from CDN
   // https://stackoverflow.com/questions/34338411/how-to-import-jquery-using-es6-syntax
@@ -223,6 +223,5 @@
     $("#view_2682 #mapIFrame").on("load", function () {
       sendLocationMapMessage("view_2682");
     });
-
   });
 })();

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -6,6 +6,7 @@ import MapGL, {
   ViewStateChangeEvent,
 } from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
+import { NavigationControl } from "react-map-gl/mapbox";
 import SignPopup from "./SignPopup";
 import { MapProps, LatLon, Sign } from "@/types/map";
 import { useCreateSignPins, useFormatBounds } from "@/utils/mapUtils";
@@ -95,6 +96,7 @@ export default function Map({ location, signs }: MapProps) {
       )}
 
       <GeocoderControl position="top-left" marker={true} />
+      <NavigationControl position="bottom-right" showCompass={false} />
     </MapGL>
   );
 }

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -52,7 +52,7 @@ export default function Map({ location, signs }: MapProps) {
   const geoLocation = useGeoLocation();
 
   /**
-   * If there are no location pins and we have a geolocation point
+   * If there are no sign locations and we have a geolocation point
    * center map at geolocation
    */
   useEffect(() => {
@@ -120,7 +120,7 @@ export default function Map({ location, signs }: MapProps) {
       <GeolocateControl
         position="top-left"
         showUserLocation={false}
-        fitBoundsOptions={{ maxZoom: 16, duration: 0 }}
+        fitBoundsOptions={{ maxZoom: 17, duration: 0 }}
       />
       <NavigationControl position="bottom-right" showCompass={false} />
     </MapGL>

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -9,7 +9,11 @@ import GeocoderControl from "@/components/MapGeocoderControl";
 import { NavigationControl, GeolocateControl } from "react-map-gl/mapbox";
 import SignPopup from "./SignPopup";
 import { MapProps, LatLon, Sign } from "@/types/map";
-import { useCreateSignPins, useFormatBounds } from "@/utils/mapUtils";
+import {
+  useCreateSignPins,
+  useFormatBounds,
+  useGeoLocation,
+} from "@/utils/mapUtils";
 import {
   DEFAULT_MAP_PARAMS,
   DEFAULT_MAP_PAN_ZOOM,
@@ -44,8 +48,10 @@ export default function Map({ location, signs }: MapProps) {
   });
 
   const bounds = useFormatBounds(signs);
-
   const signPins = useCreateSignPins(signs, setPopupInfo);
+  const geoLocation = useGeoLocation();
+
+  console.log(geoLocation);
 
   useEffect(() => {
     if (!mapRef?.current || !bounds) {

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -37,7 +37,7 @@ export default function Map({ location, signs }: MapProps) {
     });
     // send location to Knack
     window.parent.postMessage(
-      { message: "LAT_LON_FIELDS", lat: latitude, lng: longitude },
+      { message: "LAT_LON_UPDATE", lat: latitude, lng: longitude },
       "https://atd.knack.com"
     );
   }, []);

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -51,8 +51,20 @@ export default function Map({ location, signs }: MapProps) {
   const signPins = useCreateSignPins(signs, setPopupInfo);
   const geoLocation = useGeoLocation();
 
-  console.log(geoLocation);
+  useEffect(() => {
+    if (!mapRef?.current || signs.length > 0) {
+      return;
+    }
+    if (geoLocation?.latitude && geoLocation.longitude) {
+      mapRef.current.jumpTo({
+        center: [geoLocation?.longitude, geoLocation?.latitude],
+      });
+    }
+  }, [geoLocation, signs]);
 
+  /**
+   * Zoom to bounding box containing location pins
+   */
   useEffect(() => {
     if (!mapRef?.current || !bounds) {
       return;
@@ -90,11 +102,11 @@ export default function Map({ location, signs }: MapProps) {
 
       {
         // showing the location / geolocation will happen in a subsequent issue
-        console.log("location from payload: ", location)
+        //  console.log("location from payload: ", location)
         // when do we show location vs signs? when there are no signs?
-        /* {location?.latitude && location?.longitude && (
-        <Marker latitude={location.latitude} longitude={location.longitude} />
-      )} */
+        location?.latitude && location?.longitude && (
+          <Marker latitude={location.latitude} longitude={location.longitude} />
+        )
       }
 
       {popupInfo && (
@@ -102,7 +114,7 @@ export default function Map({ location, signs }: MapProps) {
       )}
 
       <GeocoderControl position="top-left" marker={true} />
-      <GeolocateControl position="top-left" />
+      <GeolocateControl position="top-left" showUserLocation={false} />
       <NavigationControl position="bottom-right" showCompass={false} />
     </MapGL>
   );

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -59,7 +59,7 @@ export default function Map({ location, signs }: MapProps) {
     if (!mapRef?.current || signs.length > 0) {
       return;
     }
-    if (geoLocation?.latitude && geoLocation.longitude) {
+    if (geoLocation?.latitude && geoLocation?.longitude) {
       mapRef.current.jumpTo({
         center: [geoLocation?.longitude, geoLocation?.latitude],
       });
@@ -109,7 +109,7 @@ export default function Map({ location, signs }: MapProps) {
         // location?.latitude && location?.longitude && (
         //   <Marker latitude={location.latitude} longitude={location.longitude} />
         // )
-        console.log(location)
+        console.log("location from iframeMessenger payload", location)
       }
 
       {popupInfo && (

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -6,7 +6,7 @@ import MapGL, {
   ViewStateChangeEvent,
 } from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
-import { NavigationControl } from "react-map-gl/mapbox";
+import { NavigationControl, GeolocateControl } from "react-map-gl/mapbox";
 import SignPopup from "./SignPopup";
 import { MapProps, LatLon, Sign } from "@/types/map";
 import { useCreateSignPins, useFormatBounds } from "@/utils/mapUtils";
@@ -96,6 +96,7 @@ export default function Map({ location, signs }: MapProps) {
       )}
 
       <GeocoderControl position="top-left" marker={true} />
+      <GeolocateControl position="top-left" />
       <NavigationControl position="bottom-right" showCompass={false} />
     </MapGL>
   );

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -51,6 +51,10 @@ export default function Map({ location, signs }: MapProps) {
   const signPins = useCreateSignPins(signs, setPopupInfo);
   const geoLocation = useGeoLocation();
 
+  /**
+   * If there are no location pins and we have a geolocation point
+   * center map at geolocation
+   */
   useEffect(() => {
     if (!mapRef?.current || signs.length > 0) {
       return;
@@ -101,9 +105,7 @@ export default function Map({ location, signs }: MapProps) {
       {signPins}
 
       {
-        // showing the location / geolocation will happen in a subsequent issue
-        //  console.log("location from payload: ", location)
-        // when do we show location vs signs? when there are no signs?
+        // the add location marker, work will be completed in a following PR
         location?.latitude && location?.longitude && (
           <Marker latitude={location.latitude} longitude={location.longitude} />
         )
@@ -114,7 +116,11 @@ export default function Map({ location, signs }: MapProps) {
       )}
 
       <GeocoderControl position="top-left" marker={true} />
-      <GeolocateControl position="top-left" showUserLocation={false} />
+      <GeolocateControl
+        position="top-left"
+        showUserLocation={false}
+        fitBoundsOptions={{ maxZoom: 16, duration: 0 }}
+      />
       <NavigationControl position="bottom-right" showCompass={false} />
     </MapGL>
   );

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -106,9 +106,10 @@ export default function Map({ location, signs }: MapProps) {
 
       {
         // the add location marker, work will be completed in a following PR
-        location?.latitude && location?.longitude && (
-          <Marker latitude={location.latitude} longitude={location.longitude} />
-        )
+        // location?.latitude && location?.longitude && (
+        //   <Marker latitude={location.latitude} longitude={location.longitude} />
+        // )
+        console.log(location)
       }
 
       {popupInfo && (

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -95,13 +95,4 @@ export type KnackToIFrameMessage =
           latitude: number | undefined;
         };
       };
-    }
-  | {
-      message: "KNACK_GEOLOCATION";
-      payload: {
-        geolocation: {
-          latitude: number | undefined;
-          longitude: number | undefined;
-        };
-      };
     };

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -26,18 +26,18 @@ export interface KnackRecord {
   /** spatial id raw format */
   field_3297_raw: number;
   /** address in string form */
-  field_3300: string;
+  field_3300: string | undefined;
   /** address raw format  */
   field_3300_raw: {
-    city: string;
-    country: string;
-    full: string;
-    latitude: number;
-    longitude: number;
-    state: string;
-    street: string;
+    city: string | undefined;
+    country: string | undefined;
+    full: string | undefined;
+    latitude: number | undefined;
+    longitude: number | undefined;
+    state: string | undefined;
+    street: string | undefined;
     street2: string | null;
-    zip: string;
+    zip: string | undefined;
   };
   /** created date */
   field_3302?: string;

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -12,7 +12,7 @@ import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
  */
 export const useFormatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
   useMemo(() => {
-    // Knack does not check if locations have legitimate latitude and longitude
+    // Knack will save undefined latitudes and longitudes, this filters those out.
     const checkedSigns = signs.filter((sign: Sign) => sign.lat && sign.lng);
 
     if (checkedSigns.length === 0) {

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -12,17 +12,12 @@ import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
  */
 export const useFormatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
   useMemo(() => {
-    // Knack will save undefined latitudes and longitudes, this filters those out.
-    const checkedSigns = signs.filter((sign: Sign) => sign.lat && sign.lng);
-
-    if (checkedSigns.length === 0) {
+      console.log(signs)
+    if (signs.length === 0) {
       return undefined;
     }
 
-    const signLatLonArray = checkedSigns.map((sign: Sign) => [
-      sign.lng,
-      sign.lat,
-    ]);
+    const signLatLonArray = signs.map((sign: Sign) => [sign.lng, sign.lat]);
 
     const lineStringFeature =
       // if there is only one sign in the array, create the linestring for the bounding box using the one sign
@@ -56,7 +51,7 @@ export const useFormatSignsRecords = (
         ? knackPayload?.payload?.locationRecordId
         : null;
 
-    return knackPayload.payload.records.map((sign) => ({
+    const signsArray = knackPayload.payload.records.map((sign) => ({
       id: sign.id,
       lat: sign.field_3300_raw.latitude,
       lng: sign.field_3300_raw.longitude,
@@ -64,6 +59,9 @@ export const useFormatSignsRecords = (
       workOrderId: knackPayload.payload.workOrderId,
       isLocationDetailPage: sign.id === locationId,
     }));
+
+    // Knack will save undefined latitudes and longitudes, this filters those out.
+    return signsArray.filter((sign: Sign) => sign.lat && sign.lng);
   }, [knackPayload]);
 
 /**

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -115,7 +115,6 @@ export const useCreateSignPins = (
                 // If we let the click event propagates to the map, it will immediately close the popup
                 // with `closeOnClick: true`
                 e.originalEvent.stopPropagation();
-                console.log(sign);
                 setPopupInfo(sign);
               }}
             />
@@ -124,11 +123,13 @@ export const useCreateSignPins = (
     [signs, setPopupInfo]
   );
 
+/**
+ * @returns If geolocation permissions are on, return LatLon
+ */
 export const useGeoLocation = () => {
   const [geoLocation, setGeoLocation] = useState<LatLon | undefined>(undefined);
 
   useEffect(() => {
-    console.log("getting location");
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(({ coords }) => {
         setGeoLocation({

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -12,11 +12,9 @@ import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
  */
 export const useFormatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
   useMemo(() => {
-      console.log(signs)
     if (signs.length === 0) {
       return undefined;
     }
-
     const signLatLonArray = signs.map((sign: Sign) => [sign.lng, sign.lat]);
 
     const lineStringFeature =

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -12,10 +12,17 @@ import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
  */
 export const useFormatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
   useMemo(() => {
-    if (signs.length === 0) {
+    // Knack does not check if locations have legitimate latitude and longitude
+    const checkedSigns = signs.filter((sign: Sign) => sign.lat && sign.lng);
+
+    if (checkedSigns.length === 0) {
       return undefined;
     }
-    const signLatLonArray = signs.map((sign: Sign) => [sign.lng, sign.lat]);
+
+    const signLatLonArray = checkedSigns.map((sign: Sign) => [
+      sign.lng,
+      sign.lat,
+    ]);
 
     const lineStringFeature =
       // if there is only one sign in the array, create the linestring for the bounding box using the one sign

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -49,17 +49,26 @@ export const useFormatSignsRecords = (
         ? knackPayload?.payload?.locationRecordId
         : null;
 
-    const signsArray = knackPayload.payload.records.map((sign) => ({
-      id: sign.id,
-      lat: sign.field_3300_raw.latitude,
-      lng: sign.field_3300_raw.longitude,
-      spatialId: sign.field_3297,
-      workOrderId: knackPayload.payload.workOrderId,
-      isLocationDetailPage: sign.id === locationId,
-    }));
-
     // Knack will save undefined latitudes and longitudes, this filters those out.
-    return signsArray.filter((sign: Sign) => sign.lat && sign.lng);
+    const signsArray: Sign[] = knackPayload.payload.records.reduce(
+      (acc: Sign[], sign) => {
+        if (sign.field_3300_raw.latitude && sign.field_3300_raw.longitude) {
+          const newSign = {
+            id: sign.id,
+            lat: sign.field_3300_raw.latitude,
+            lng: sign.field_3300_raw.longitude,
+            spatialId: sign.field_3297,
+            workOrderId: knackPayload.payload.workOrderId,
+            isLocationDetailPage: sign.id === locationId,
+          };
+          acc.push(newSign);
+        }
+        return acc;
+      },
+      []
+    );
+
+    return signsArray;
   }, [knackPayload]);
 
 /**

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
 import { LngLatBoundsLike } from "mapbox-gl";
@@ -123,3 +123,21 @@ export const useCreateSignPins = (
       ),
     [signs, setPopupInfo]
   );
+
+export const useGeoLocation = () => {
+  const [geoLocation, setGeoLocation] = useState<LatLon | undefined>(undefined);
+
+  useEffect(() => {
+    console.log("getting location");
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(({ coords }) => {
+        setGeoLocation({
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+        });
+      });
+    }
+  }, []);
+
+  return geoLocation;
+};

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -47,10 +47,7 @@ export const useFormatSignsRecords = (
 ): Sign[] =>
   useMemo(() => {
     if (!knackPayload) return [];
-    if (
-      knackPayload?.message === "EDIT_LOCATION" ||
-      knackPayload?.message === "KNACK_GEOLOCATION"
-    ) {
+    if (knackPayload?.message === "EDIT_LOCATION") {
       return [];
     }
 
@@ -80,13 +77,6 @@ export const useFormatLocation = (
   useMemo(() => {
     if (!knackPayload || knackPayload?.message === "WORK_ORDER_SIGNS") {
       return { longitude: undefined, latitude: undefined };
-    }
-
-    if (knackPayload.message === "KNACK_GEOLOCATION") {
-      return {
-        longitude: knackPayload.payload.geolocation.longitude,
-        latitude: knackPayload.payload.geolocation.latitude,
-      };
     }
 
     return {


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/21822

This PR adds geolocation to the map. If there are no sign locations on the work order, the map should center at the user's location. If there are sign locations, then the map should fit the signs in view and not zoom to the user's location.

Previously, the javascript code in the iframeMessenger file requested the user's location from the browser and then used the iFrame messaging setup to convey that location to the react app. Now we are instead going to request the location from within the react app and skip the iFrame part. 

I have also added Mapbox's `GeolocateControl` so a user can center the map on their location even after the map first loads. 


### Testing instructions
https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/

sign in as a non-coa user, `test-tech@austintexas.gov`, the password is in 1pw under SMD test technician


Pick a work order without locations, for [example](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/664e15bd565e0100284b7df5/)
As long as you have location permissions turned on, the map should center on your location. 

Pick a work order with locations, [this one](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/5d3f0fa2fa75350013d8b90e/) or [the one from the last PR](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/5fa5b8264416d10019334024/). The map does not center at your location, but centers around the signs. 

Test out the GeolocateControl button. Do you think it will be useful to technicians?
<img width="416" alt="Screenshot 2025-06-23 at 5 26 49 PM" src="https://github.com/user-attachments/assets/19900cba-4bf9-4789-8b26-a10983b36f96" />

Adding locations still isn't in the scope of this PR, and knack doesn't prevent a user from saving an empty location form. But I added some checks so that the app does not crash if the locations are malformed. 

