### PR TITLE
Ability to create new locations

### DIFF
--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -9,14 +9,14 @@ export default function Home() {
 
   console.log(knackPayload);
 
-  const location = useFormatLocation(knackPayload);
+  // const location = useFormatLocation(knackPayload);
   const signs = useFormatSignsRecords(knackPayload);
 
   return (
     <div className={styles.page}>
       <main className={styles.main}>
         <div className={styles.map}>
-          <Map location={location} signs={signs} />
+          <Map signs={signs} messageType={knackPayload?.message}/>
         </div>
       </main>
     </div>

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -2,12 +2,10 @@
 import styles from "./page.module.css";
 import Map from "@/components/Map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
-import { useFormatSignsRecords, useFormatLocation } from "@/utils/mapUtils";
+import { useFormatSignsRecords } from "@/utils/mapUtils";
 
 export default function Home() {
   const knackPayload = useIFrameMessenger();
-
-  console.log(knackPayload);
 
   // const location = useFormatLocation(knackPayload);
   const signs = useFormatSignsRecords(knackPayload);

--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
     <div className={styles.page}>
       <main className={styles.main}>
         <div className={styles.map}>
-          <Map signs={signs} messageType={knackPayload?.message}/>
+          <Map signs={signs} messageType={knackPayload?.message} />
         </div>
       </main>
     </div>

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -4,9 +4,10 @@ import MapGL, {
   MapRef,
   Marker,
   ViewStateChangeEvent,
+  NavigationControl,
+  GeolocateControl,
 } from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
-import { NavigationControl, GeolocateControl } from "react-map-gl/mapbox";
 import SignPopup from "./SignPopup";
 import { sendLatLonToParent } from "@/utils/iFrameMessenger";
 import { MapProps, LatLon, Sign } from "@/types/map";
@@ -38,6 +39,18 @@ export default function Map({ signs, messageType }: MapProps) {
     const longitude = +event.viewState.longitude.toFixed(
       MAP_COORDINATE_PRECISION
     );
+    setMapLatLon({
+      latitude,
+      longitude,
+    });
+
+    sendLatLonToParent({ latitude, longitude });
+  }, []);
+
+  const onGeolocate = useCallback((data: GeolocationPosition) => {
+    // truncate values to our preferred precision
+    const latitude = +data.coords.latitude.toFixed(MAP_COORDINATE_PRECISION);
+    const longitude = +data.coords.longitude.toFixed(MAP_COORDINATE_PRECISION);
     setMapLatLon({
       latitude,
       longitude,
@@ -138,6 +151,7 @@ export default function Map({ signs, messageType }: MapProps) {
         position="top-left"
         showUserLocation={false}
         fitBoundsOptions={{ maxZoom: 16, duration: 0 }}
+        onGeolocate={onGeolocate}
       />
       <NavigationControl position="bottom-right" showCompass={false} />
     </MapGL>

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -21,6 +21,12 @@ import {
   MAP_COORDINATE_PRECISION,
 } from "@/config/map";
 
+/**
+ *
+ * @param signs Array of Signs from knack paylod, or empty array
+ * @param messageType String from knack payload
+ * @returns
+ */
 export default function Map({ signs, messageType }: MapProps) {
   const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
@@ -50,8 +56,8 @@ export default function Map({ signs, messageType }: MapProps) {
   const geoLocation = useGeoLocation();
 
   /**
-   * If there are no location pins and we have a geolocation point
-   * center map at geolocation. Set add location marker to same coords as geolocation
+   * If there are no location pins and we have a geolocation point center
+   * map at geolocation. Set add location marker to same coordindates as geolocation
    */
   useEffect(() => {
     if (!mapRef?.current || signs.length > 0) {
@@ -71,7 +77,7 @@ export default function Map({ signs, messageType }: MapProps) {
 
   /**
    * Zoom to bounding box containing location pins
-   * and set add location marker to center
+   * and set "add location marker" coordinates to center
    */
   useEffect(() => {
     if (!mapRef?.current || !bounds) {
@@ -119,7 +125,6 @@ export default function Map({ signs, messageType }: MapProps) {
         )}
 
       {signPins}
-
       {popupInfo && (
         <SignPopup popupInfo={popupInfo} setPopupInfo={setPopupInfo} />
       )}

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -133,11 +133,7 @@ export default function Map({ signs, messageType }: MapProps) {
         <SignPopup popupInfo={popupInfo} setPopupInfo={setPopupInfo} />
       )}
 
-      <GeocoderControl
-        position="top-left"
-        marker={false}
-        setMapLatLon={setMapLatLon}
-      />
+      <GeocoderControl position="top-left" setMapLatLon={setMapLatLon} />
       <GeolocateControl
         position="top-left"
         showUserLocation={false}

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -114,7 +114,7 @@ export default function Map({ signs, messageType }: MapProps) {
     >
       {
         // red "add location" marker that is situated at center of map. This marker's location is
-        // what is sent to knack in the LAT_LON_PAYLOAD message
+        // what is sent to knack in the LAT_LON_UPDATE payload message
         mapLatLon?.latitude &&
           mapLatLon?.longitude &&
           messageType !== "KNACK_LOCATION_DETAILS" && (

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -35,6 +35,9 @@ export default function Map({ signs, messageType }: MapProps) {
       latitude,
       longitude,
     });
+
+    // todo: pull this out of here, so it can be a callable function
+    // and should send a message before dragging too
     // send location to Knack
     window.parent.postMessage(
       { message: "LAT_LON_FIELDS", lat: latitude, lng: longitude },
@@ -53,7 +56,7 @@ export default function Map({ signs, messageType }: MapProps) {
 
   /**
    * If there are no location pins and we have a geolocation point
-   * center map at geolocation
+   * center map at geolocation. Set add location marker to same coords as geolocation
    */
   useEffect(() => {
     if (!mapRef?.current || signs.length > 0) {
@@ -63,11 +66,17 @@ export default function Map({ signs, messageType }: MapProps) {
       mapRef.current.jumpTo({
         center: [geoLocation?.longitude, geoLocation?.latitude],
       });
+
+      setMapLatLon({
+        latitude: geoLocation.latitude,
+        longitude: geoLocation.longitude,
+      });
     }
   }, [geoLocation, signs]);
 
   /**
    * Zoom to bounding box containing location pins
+   * and set add location marker to center
    */
   useEffect(() => {
     if (!mapRef?.current || !bounds) {
@@ -78,6 +87,12 @@ export default function Map({ signs, messageType }: MapProps) {
       padding: 100,
       maxZoom: 16,
       duration: 0,
+    });
+
+    const { lng, lat } = mapRef.current.getCenter();
+    setMapLatLon({
+      latitude: lat,
+      longitude: lng,
     });
   }, [bounds]);
 
@@ -92,6 +107,7 @@ export default function Map({ signs, messageType }: MapProps) {
       cooperativeGestures={true}
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
+      onLoad={() => console.log(mapRef.current)}
     >
       {mapLatLon?.latitude &&
         mapLatLon?.longitude &&

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -20,7 +20,7 @@ import {
   MAP_COORDINATE_PRECISION,
 } from "@/config/map";
 
-export default function Map({ location, signs }: MapProps) {
+export default function Map({ signs, messageType }: MapProps) {
   const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
   const onDrag = useCallback((event: ViewStateChangeEvent) => {
@@ -93,24 +93,19 @@ export default function Map({ location, signs }: MapProps) {
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
     >
-      {signs.length < 1 && mapLatLon?.latitude && mapLatLon?.longitude && (
-        <Marker
-          longitude={mapLatLon.longitude}
-          latitude={mapLatLon.latitude}
-          // draggable
-          //red?
-        />
-      )}
+      {mapLatLon?.latitude &&
+        mapLatLon?.longitude &&
+        messageType !== "KNACK_LOCATION_DETAILS" && (
+          <Marker
+            longitude={mapLatLon.longitude}
+            latitude={mapLatLon.latitude}
+            anchor="bottom"
+            color={"red"}
+            rotation={45} // trying this now to differentiate instead of pulse
+          />
+        )}
 
       {signPins}
-
-      {
-        // the add location marker, work will be completed in a following PR
-        // location?.latitude && location?.longitude && (
-        //   <Marker latitude={location.latitude} longitude={location.longitude} />
-        // )
-        console.log(location)
-      }
 
       {popupInfo && (
         <SignPopup popupInfo={popupInfo} setPopupInfo={setPopupInfo} />

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -23,7 +23,7 @@ import {
 
 /**
  *
- * @param signs Array of Signs from knack paylod, or empty array
+ * @param signs Array of Signs from knack payload, or empty array
  * @param messageType String from knack payload
  * @returns
  */
@@ -56,7 +56,7 @@ export default function Map({ signs, messageType }: MapProps) {
   const geoLocation = useGeoLocation();
 
   /**
-   * If there are no location pins and we have a geolocation point center
+   * If there are no sign location pins and we have a geolocation point center
    * map at geolocation. Set add location marker to same coordindates as geolocation
    */
   useEffect(() => {

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -123,6 +123,7 @@ export default function Map({ signs, messageType }: MapProps) {
       {...DEFAULT_MAP_PARAMS}
       onDrag={updateCenterMarker}
       onZoom={updateCenterMarker}
+      onMoveEnd={updateCenterMarker}
       onLoad={() => {
         sendLatLonToParent(mapLatLon);
       }}

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -112,17 +112,21 @@ export default function Map({ signs, messageType }: MapProps) {
         sendLatLonToParent(mapLatLon);
       }}
     >
-      {mapLatLon?.latitude &&
-        mapLatLon?.longitude &&
-        messageType !== "KNACK_LOCATION_DETAILS" && (
-          <Marker
-            longitude={mapLatLon.longitude}
-            latitude={mapLatLon.latitude}
-            anchor="bottom"
-            color={"red"}
-            rotation={45} // trying this now to differentiate instead of pulse
-          />
-        )}
+      {
+        // red "add location" marker that is situated at center of map. This marker's location is
+        // what is sent to knack in the LAT_LON_PAYLOAD message
+        mapLatLon?.latitude &&
+          mapLatLon?.longitude &&
+          messageType !== "KNACK_LOCATION_DETAILS" && (
+            <Marker
+              longitude={mapLatLon.longitude}
+              latitude={mapLatLon.latitude}
+              anchor="bottom"
+              color={"red"}
+              rotation={45} // trying this now to differentiate instead of pulse
+            />
+          )
+      }
 
       {signPins}
       {popupInfo && (

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -133,7 +133,11 @@ export default function Map({ signs, messageType }: MapProps) {
         <SignPopup popupInfo={popupInfo} setPopupInfo={setPopupInfo} />
       )}
 
-      <GeocoderControl position="top-left" marker={true} />
+      <GeocoderControl
+        position="top-left"
+        marker={false}
+        setMapLatLon={setMapLatLon}
+      />
       <GeolocateControl
         position="top-left"
         showUserLocation={false}

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -8,6 +8,7 @@ import MapGL, {
 import GeocoderControl from "@/components/MapGeocoderControl";
 import { NavigationControl, GeolocateControl } from "react-map-gl/mapbox";
 import SignPopup from "./SignPopup";
+import { sendLatLonToParent } from "@/utils/iFrameMessenger";
 import { MapProps, LatLon, Sign } from "@/types/map";
 import {
   useCreateSignPins,
@@ -36,13 +37,7 @@ export default function Map({ signs, messageType }: MapProps) {
       longitude,
     });
 
-    // todo: pull this out of here, so it can be a callable function
-    // and should send a message before dragging too
-    // send location to Knack
-    window.parent.postMessage(
-      { message: "LAT_LON_FIELDS", lat: latitude, lng: longitude },
-      "https://atd.knack.com"
-    );
+    sendLatLonToParent({ latitude, longitude });
   }, []);
 
   const [mapLatLon, setMapLatLon] = useState<LatLon>({
@@ -91,8 +86,8 @@ export default function Map({ signs, messageType }: MapProps) {
 
     const { lng, lat } = mapRef.current.getCenter();
     setMapLatLon({
-      latitude: lat,
-      longitude: lng,
+      latitude: +lat.toFixed(MAP_COORDINATE_PRECISION),
+      longitude: +lng.toFixed(MAP_COORDINATE_PRECISION),
     });
   }, [bounds]);
 
@@ -107,7 +102,9 @@ export default function Map({ signs, messageType }: MapProps) {
       cooperativeGestures={true}
       {...DEFAULT_MAP_PARAMS}
       onDrag={onDrag}
-      onLoad={() => console.log(mapRef.current)}
+      onLoad={() => {
+        sendLatLonToParent(mapLatLon);
+      }}
     >
       {mapLatLon?.latitude &&
         mapLatLon?.longitude &&

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -31,7 +31,8 @@ import {
 export default function Map({ signs, messageType }: MapProps) {
   const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
-  const onDrag = useCallback((event: ViewStateChangeEvent) => {
+  const [zoomLevel, setZoomLevel] = useState<number>(DEFAULT_MAP_PAN_ZOOM.zoom)
+  const updateCenterMarker = useCallback((event: ViewStateChangeEvent) => {
     // truncate values to our preferred precision
     const latitude = +event.viewState.latitude.toFixed(
       MAP_COORDINATE_PRECISION
@@ -46,6 +47,7 @@ export default function Map({ signs, messageType }: MapProps) {
 
     sendLatLonToParent({ latitude, longitude });
   }, []);
+
 
   const onGeolocate = useCallback((data: GeolocationPosition) => {
     // truncate values to our preferred precision
@@ -65,7 +67,7 @@ export default function Map({ signs, messageType }: MapProps) {
   });
 
   const bounds = useFormatBounds(signs);
-  const signPins = useCreateSignPins(signs, setPopupInfo);
+  const signPins = useCreateSignPins(signs, setPopupInfo, zoomLevel);
   const geoLocation = useGeoLocation();
 
   /**
@@ -120,10 +122,12 @@ export default function Map({ signs, messageType }: MapProps) {
       }}
       cooperativeGestures={true}
       {...DEFAULT_MAP_PARAMS}
-      onDrag={onDrag}
+      onDrag={updateCenterMarker}
+      onZoom={updateCenterMarker}
       onLoad={() => {
         sendLatLonToParent(mapLatLon);
       }}
+
     >
       {
         // red "add location" marker that is situated at center of map. This marker's location is

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -31,7 +31,6 @@ import {
 export default function Map({ signs, messageType }: MapProps) {
   const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
-  const [zoomLevel, setZoomLevel] = useState<number>(DEFAULT_MAP_PAN_ZOOM.zoom)
   const updateCenterMarker = useCallback((event: ViewStateChangeEvent) => {
     // truncate values to our preferred precision
     const latitude = +event.viewState.latitude.toFixed(
@@ -67,7 +66,7 @@ export default function Map({ signs, messageType }: MapProps) {
   });
 
   const bounds = useFormatBounds(signs);
-  const signPins = useCreateSignPins(signs, setPopupInfo, zoomLevel);
+  const signPins = useCreateSignPins(signs, setPopupInfo);
   const geoLocation = useGeoLocation();
 
   /**
@@ -127,7 +126,6 @@ export default function Map({ signs, messageType }: MapProps) {
       onLoad={() => {
         sendLatLonToParent(mapLatLon);
       }}
-
     >
       {
         // red "add location" marker that is situated at center of map. This marker's location is
@@ -138,7 +136,6 @@ export default function Map({ signs, messageType }: MapProps) {
             <Marker
               longitude={mapLatLon.longitude}
               latitude={mapLatLon.latitude}
-              anchor="bottom"
               color={"red"}
               rotation={45} // trying this now to differentiate instead of pulse
             />

--- a/signs-work-order-map/components/MapGeocoderControl.tsx
+++ b/signs-work-order-map/components/MapGeocoderControl.tsx
@@ -17,6 +17,7 @@ type GeocoderControlProps = Omit<
 > & {
   marker?: boolean | Omit<MarkerProps, "longitude" | "latitude">;
 
+  /** Where in the map should the geocoder appear */
   position: ControlPosition;
 
   onLoading?: (e: object) => void;
@@ -48,15 +49,15 @@ export default function GeocoderControl(props: GeocoderControlProps) {
           result &&
           (result.center ||
             (result.geometry?.type === "Point" && result.geometry.coordinates));
-        if (result.center[0] && result.center[1]) {
+        if (location) {
           props.setMapLatLon({
-            longitude: result.center[0],
-            latitude: result.center[1],
+            longitude: location[0],
+            latitude: location[1],
           });
           sendLatLonToParent({
-            longitude: result.center[0],
-            latitude: result.center[1],
-          })
+            longitude: location[0],
+            latitude: location[1],
+          });
         }
         if (location && props.marker) {
           const markerProps =

--- a/signs-work-order-map/components/MapGeocoderControl.tsx
+++ b/signs-work-order-map/components/MapGeocoderControl.tsx
@@ -7,6 +7,9 @@ import {
 } from "react-map-gl/mapbox";
 import MapboxGeocoder, { GeocoderOptions } from "@mapbox/mapbox-gl-geocoder";
 import "@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css";
+import { MAPBOX_TOKEN } from "@/config/map";
+import { LatLon } from "@/types/map";
+import { sendLatLonToParent } from "@/utils/iFrameMessenger";
 
 type GeocoderControlProps = Omit<
   GeocoderOptions,
@@ -20,9 +23,9 @@ type GeocoderControlProps = Omit<
   onResults?: (e: object) => void;
   onResult?: (e: object) => void;
   onError?: (e: object) => void;
+  setMapLatLon: (value: LatLon) => void;
 };
 
-const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
 const ATX_BOUNDING_BOX: [number, number, number, number] = [
   -98.182, 29.987, -97.304, 30.663,
 ];
@@ -45,6 +48,16 @@ export default function GeocoderControl(props: GeocoderControlProps) {
           result &&
           (result.center ||
             (result.geometry?.type === "Point" && result.geometry.coordinates));
+        if (result.center[0] && result.center[1]) {
+          props.setMapLatLon({
+            longitude: result.center[0],
+            latitude: result.center[1],
+          });
+          sendLatLonToParent({
+            longitude: result.center[0],
+            latitude: result.center[1],
+          })
+        }
         if (location && props.marker) {
           const markerProps =
             typeof props.marker === "object" ? props.marker : {};
@@ -123,19 +136,6 @@ export default function GeocoderControl(props: GeocoderControlProps) {
     if (geocoder.getOrigin() !== props.origin && props.origin !== undefined) {
       geocoder.setOrigin(props.origin);
     }
-    // Types missing from @types/mapbox__mapbox-gl-geocoder
-    // if (geocoder.getAutocomplete() !== props.autocomplete && props.autocomplete !== undefined) {
-    //   geocoder.setAutocomplete(props.autocomplete);
-    // }
-    // if (geocoder.getFuzzyMatch() !== props.fuzzyMatch && props.fuzzyMatch !== undefined) {
-    //   geocoder.setFuzzyMatch(props.fuzzyMatch);
-    // }
-    // if (geocoder.getRouting() !== props.routing && props.routing !== undefined) {
-    //   geocoder.setRouting(props.routing);
-    // }
-    // if (geocoder.getWorldview() !== props.worldview && props.worldview !== undefined) {
-    //   geocoder.setWorldview(props.worldview);
-    // }
   }
   return marker;
 }

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -3,7 +3,7 @@ import "mapbox-gl/dist/mapbox-gl.css";
 
 // // The Nearmap API key is managed by CTM. Contact help desk for maintenance and troubleshooting.
 // const NEARMAP_KEY = process.env.NEXT_PUBLIC_NEARMAP_KEY;
-const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+export const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
 
 
 // TODO: update to prod url when testing is completed

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -4,10 +4,11 @@ export interface LatLon {
 }
 
 export interface MapProps {
-  location: {
+  location?: {
     longitude: number | undefined;
     latitude: number | undefined;
   };
+  messageType?: "KNACK_LOCATION_DETAILS" | "EDIT_LOCATION" | "WORK_ORDER_SIGNS";
   signs: Sign[];
 }
 

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -18,6 +18,7 @@ export interface Sign {
   lat: number;
   spatialId: number;
   workOrderId: string;
+  /** if the sign id matches the location record id, the payload came from the location details page */
   isLocationDetailPage: boolean;
 }
 

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -27,7 +27,7 @@ export function useIFrameMessenger() {
 export function sendLatLonToParent(coords: LatLon) {
   // send location to Knack
   window.parent.postMessage(
-    { message: "LAT_LON_FIELDS", lat: coords.latitude, lng: coords.longitude },
+    { message: "LAT_LON_UPDATE", lat: coords.latitude, lng: coords.longitude },
     "https://atd.knack.com"
   );
 }

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { KnackToIFrameMessage } from "@/types/map";
+import { KnackToIFrameMessage, LatLon } from "@/types/map";
 
 export function useIFrameMessenger() {
   const [message, setMessage] = useState<KnackToIFrameMessage | null>(null);
@@ -22,4 +22,12 @@ export function useIFrameMessenger() {
   }, []);
 
   return message;
+}
+
+export function sendLatLonToParent(coords: LatLon) {
+  // send location to Knack
+  window.parent.postMessage(
+    { message: "LAT_LON_FIELDS", lat: coords.latitude, lng: coords.longitude },
+    "https://atd.knack.com"
+  );
 }

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -7,8 +7,8 @@ import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
 import { MAP_COORDINATE_PRECISION } from "@/config/map";
 
 /**
- * Takes array of Signs and if signs exist, returns bounding box for signs
- * @param signs
+ * Takes array of Signs from knack payload and if signs exist, returns bounding box for signs
+ * @param signs Array of Signs
  * @returns bbox extent in [minX, minY, maxX, maxY] order or undefined
  */
 export const useFormatBounds = (signs: Sign[]): undefined | LngLatBoundsLike =>
@@ -90,7 +90,7 @@ export const useFormatLocation = (
  * Takes array of Signs and returns array of map markers, one marker per sign
  * If the sign id matches the location detail page id, render the marker as red
  * otherwise, use default color
- * @param signs
+ * @param signs Array of Signs
  * @returns Array of Map Markers
  */
 export const useCreateSignPins = (

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -112,7 +112,6 @@ export const useCreateSignPins = (
               key={`marker-${sign.id}`}
               longitude={sign.lng}
               latitude={sign.lat}
-              anchor="bottom"
               color={sign.isLocationDetailPage ? "red" : undefined}
               onClick={(e) => {
                 // If we let the click event propagates to the map, it will immediately close the popup

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -4,6 +4,7 @@ import { lineString } from "@turf/helpers";
 import { LngLatBoundsLike } from "mapbox-gl";
 import { Marker } from "react-map-gl/mapbox";
 import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
+import { MAP_COORDINATE_PRECISION } from "@/config/map";
 
 /**
  * Takes array of Signs and if signs exist, returns bounding box for signs
@@ -69,14 +70,14 @@ export const useFormatSignsRecords = (
 /**
  * Function that takes data from knack app and depending on message type, returns location
  * @param knackPayload - message from Knack via IFrameMessage
- * @returns LatLon object
+ * @returns LatLon object or null
  */
 export const useFormatLocation = (
   knackPayload: KnackToIFrameMessage | null
-): LatLon =>
+): LatLon | null =>
   useMemo(() => {
     if (!knackPayload || knackPayload?.message === "WORK_ORDER_SIGNS") {
-      return { longitude: undefined, latitude: undefined };
+      return null;
     }
 
     return {
@@ -130,8 +131,8 @@ export const useGeoLocation = () => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(({ coords }) => {
         setGeoLocation({
-          latitude: coords.latitude,
-          longitude: coords.longitude,
+          latitude: +coords.latitude.toFixed(MAP_COORDINATE_PRECISION),
+          longitude: +coords.longitude.toFixed(MAP_COORDINATE_PRECISION),
         });
       });
     }


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/21823

The Add Location button appears when a Work Order has the status "Issued".  In production there is a pulsing red marker that appears, in this PR I am using a red marker at an angle. [ Here](https://github.com/cityofaustin/atd-knack-signs-markings/blob/staging/src/index.css#L277) are the styles that in production, I want to get confirmation from Christina that  we should still use the pulsing red marker. The location detail pages use a red marker to signify which location is being viewed and I don't know if that is too similar to the add location marker. 

### Testing instructions

https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/

sign in as a non-coa user, test-tech@austintexas.gov, the password is in 1pw under SMD test technician

Go to a work order with the status ISSUED. 
Try adding a location
1. Based on your geolocation that happens on map load/ the default map location
2. Dragging the map around to a place and then adding location
3. using the geolocate input (with only basic addresses until https://github.com/cityofaustin/atd-data-tech/issues/21953 is addressed)
4.  Clicking the geolocate button

The page will reload and your new location will be in the locations table immediately above the iframe map. 