### PR TITLE
Ability to edit existing knack locations

### DIFF
--- a/signs-work-order-map/app/page.tsx
+++ b/signs-work-order-map/app/page.tsx
@@ -2,19 +2,23 @@
 import styles from "./page.module.css";
 import Map from "@/components/Map";
 import { useIFrameMessenger } from "@/utils/iFrameMessenger";
-import { useFormatSignsRecords } from "@/utils/mapUtils";
+import { useFormatSignsRecords, useFormatLocation } from "@/utils/mapUtils";
 
 export default function Home() {
   const knackPayload = useIFrameMessenger();
 
-  // const location = useFormatLocation(knackPayload);
+  const editLocation = useFormatLocation(knackPayload);
   const signs = useFormatSignsRecords(knackPayload);
 
   return (
     <div className={styles.page}>
       <main className={styles.main}>
         <div className={styles.map}>
-          <Map signs={signs} messageType={knackPayload?.message} />
+          <Map
+            signs={signs}
+            messageType={knackPayload?.message}
+            editLocation={editLocation}
+          />
         </div>
       </main>
     </div>

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -70,7 +70,8 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
 
   /**
    * If there are no sign location pins and we have a geolocation point center
-   * map at geolocation. Set add location marker to same coordindates as geolocation
+   * map at geolocation *unless we are editing an existing saved location*.
+   * Set add location marker to same coordindates as geolocation
    */
   useEffect(() => {
     if (
@@ -115,7 +116,9 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
   }, [bounds]);
 
   /***
-   *
+   * editLocation is sent from knack when a GIS Tech is on the Edit Location view
+   * center map on location, and send coordinates back to Knack to populate the
+   * location form
    */
   useEffect(() => {
     if (!mapRef?.current || !editLocation) {

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -28,7 +28,7 @@ import {
  * @param messageType String from knack payload
  * @returns
  */
-export default function Map({ signs, messageType }: MapProps) {
+export default function Map({ signs, messageType, editLocation }: MapProps) {
   const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
   const onDrag = useCallback((event: ViewStateChangeEvent) => {

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -73,7 +73,11 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
    * map at geolocation. Set add location marker to same coordindates as geolocation
    */
   useEffect(() => {
-    if (!mapRef?.current || signs.length > 0) {
+    if (
+      !mapRef?.current ||
+      signs.length > 0 ||
+      messageType === "EDIT_LOCATION"
+    ) {
       return;
     }
     if (geoLocation?.latitude && geoLocation?.longitude) {
@@ -86,7 +90,7 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
         longitude: geoLocation.longitude,
       });
     }
-  }, [geoLocation, signs]);
+  }, [geoLocation, signs, messageType]);
 
   /**
    * Zoom to bounding box containing location pins
@@ -109,6 +113,26 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
       longitude: +lng.toFixed(MAP_COORDINATE_PRECISION),
     });
   }, [bounds]);
+
+  /***
+   *
+   */
+  useEffect(() => {
+    if (!mapRef?.current || !editLocation) {
+      return;
+    }
+
+    if (editLocation.latitude && editLocation.longitude) {
+      mapRef.current.jumpTo({
+        center: [editLocation?.longitude, editLocation?.latitude],
+      });
+
+      setMapLatLon({
+        latitude: editLocation.latitude,
+        longitude: editLocation.longitude,
+      });
+    }
+  }, [editLocation]);
 
   return (
     <MapGL

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -69,19 +69,27 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
   const geoLocation = useGeoLocation();
 
   /**
-   * If there are no sign location pins and we have a geolocation point center
-   * map at geolocation *unless we are editing an existing saved location*.
-   * Set add location marker to same coordindates as geolocation
+   * Map jumpTo center useEffect
+   * If there are no sign location pins and not editing an existing location,
+   * center at geolocation.
+   * If editing an existing location, center at that location.
+   * Set add location marker to same coordinates as center
    */
   useEffect(() => {
-    if (
-      !mapRef?.current ||
-      signs.length > 0 ||
-      messageType === "EDIT_LOCATION"
-    ) {
+    if (!mapRef?.current || signs.length > 0) {
       return;
     }
-    if (geoLocation?.latitude && geoLocation?.longitude) {
+
+    if (editLocation?.latitude && editLocation?.longitude) {
+      mapRef.current.jumpTo({
+        center: [editLocation?.longitude, editLocation?.latitude],
+      });
+
+      setMapLatLon({
+        latitude: editLocation.latitude,
+        longitude: editLocation.longitude,
+      });
+    } else if (geoLocation?.latitude && geoLocation?.longitude) {
       mapRef.current.jumpTo({
         center: [geoLocation?.longitude, geoLocation?.latitude],
       });
@@ -91,7 +99,7 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
         longitude: geoLocation.longitude,
       });
     }
-  }, [geoLocation, signs, messageType]);
+  }, [geoLocation, signs, messageType, editLocation]);
 
   /**
    * Zoom to bounding box containing location pins
@@ -114,28 +122,6 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
       longitude: +lng.toFixed(MAP_COORDINATE_PRECISION),
     });
   }, [bounds]);
-
-  /**
-   * editLocation is sent from knack when a GIS Tech is on the Edit Location view
-   * center map on location, and send coordinates back to Knack to populate the
-   * location form
-   */
-  useEffect(() => {
-    if (!mapRef?.current || !editLocation) {
-      return;
-    }
-
-    if (editLocation.latitude && editLocation.longitude) {
-      mapRef.current.jumpTo({
-        center: [editLocation?.longitude, editLocation?.latitude],
-      });
-
-      setMapLatLon({
-        latitude: editLocation.latitude,
-        longitude: editLocation.longitude,
-      });
-    }
-  }, [editLocation]);
 
   return (
     <MapGL
@@ -164,7 +150,6 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
               longitude={mapLatLon.longitude}
               latitude={mapLatLon.latitude}
               color={"red"}
-              rotation={45} // trying this now to differentiate instead of pulse
             />
           )
       }

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -31,6 +31,11 @@ import {
 export default function Map({ signs, messageType, editLocation }: MapProps) {
   const mapRef = useRef<MapRef>(null);
   const [popupInfo, setPopupInfo] = useState<Sign | null>(null);
+  const [mapLatLon, setMapLatLon] = useState<LatLon>({
+    latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
+    longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
+  });
+  // when map is dragged, set lat/lon state and send location to knack
   const onDrag = useCallback((event: ViewStateChangeEvent) => {
     // truncate values to our preferred precision
     const latitude = +event.viewState.latitude.toFixed(
@@ -47,6 +52,7 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
     sendLatLonToParent({ latitude, longitude });
   }, []);
 
+  // when geolocation icon is tapped, set lat/lon state and send location to knack
   const onGeolocate = useCallback((data: GeolocationPosition) => {
     // truncate values to our preferred precision
     const latitude = +data.coords.latitude.toFixed(MAP_COORDINATE_PRECISION);
@@ -58,11 +64,6 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
 
     sendLatLonToParent({ latitude, longitude });
   }, []);
-
-  const [mapLatLon, setMapLatLon] = useState<LatLon>({
-    latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
-    longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
-  });
 
   const bounds = useFormatBounds(signs);
   const signPins = useCreateSignPins(signs, setPopupInfo);
@@ -115,7 +116,7 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
     });
   }, [bounds]);
 
-  /***
+  /**
    * editLocation is sent from knack when a GIS Tech is on the Edit Location view
    * center map on location, and send coordinates back to Knack to populate the
    * location form

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -4,10 +4,7 @@ export interface LatLon {
 }
 
 export interface MapProps {
-  location?: {
-    longitude: number | undefined;
-    latitude: number | undefined;
-  };
+  editLocation?: LatLon | null;
   messageType?: "KNACK_LOCATION_DETAILS" | "EDIT_LOCATION" | "WORK_ORDER_SIGNS";
   signs: Sign[];
 }

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -81,7 +81,7 @@ export const useFormatLocation = (
   knackPayload: KnackToIFrameMessage | null
 ): LatLon | null =>
   useMemo(() => {
-    if (!knackPayload || knackPayload?.message === "WORK_ORDER_SIGNS") {
+    if (!knackPayload || knackPayload?.message !== "EDIT_LOCATION") {
       return null;
     }
 


### PR DESCRIPTION
In production, only GIS Technicians see the edit location link on a location details page - 

### Testing instructions

to see these changes, update [the file in s3 ](https://atd-knack-signs-markings.s3.us-east-1.amazonaws.com/staging/iframeMapMessengerDev.js)to point to either this PR or localhost. 

https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/

sign in as a non-coa user, test-tech@austintexas.gov, the password is in 1pw under SMD test technician

Go to a work order with the status ISSUED with existing locations

Click on a location's details icon to see it's location details page.
<img width="637" height="213" alt="Screenshot 2025-07-14 at 3 46 12 PM" src="https://github.com/user-attachments/assets/ba34b9c9-2572-442c-8308-08250cf88f66" />


 at the top there should be an edit link 

<img width="1096" height="197" alt="Screenshot 2025-07-14 at 3 45 18 PM" src="https://github.com/user-attachments/assets/836f2429-61dd-4169-8f64-5d5ad2db7e33" />

The map loads with that location as the center. It's latitude and longitude are in form below the map. You can drag the map to move the marker and the lat/lon update below. "Submit" saves the update. 
