### PR TITLE
Adds pop-ups for rendered AGOL sign locations

### DIFF
--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -7,9 +7,9 @@
 (function () {
   var myView = window.viewIdsArray.shift(0);
 
-  // const nextAppUrl =
-  //   "https://deploy-preview-328--nextjs-knack-signs-markings.netlify.app/";
-  const nextAppUrl = "http://localhost:3000";
+  const nextAppUrl =
+    "https://deploy-preview-339--nextjs-knack-signs-markings.netlify.app;
+  // const nextAppUrl = "http://localhost:3000";
 
   // Import jQuery into this file from CDN
   // https://stackoverflow.com/questions/34338411/how-to-import-jquery-using-es6-syntax

--- a/knack/iframeMapMessenger.js
+++ b/knack/iframeMapMessenger.js
@@ -8,7 +8,7 @@
   var myView = window.viewIdsArray.shift(0);
 
   const nextAppUrl =
-    "https://deploy-preview-339--nextjs-knack-signs-markings.netlify.app;
+    "https://deploy-preview-339--nextjs-knack-signs-markings.netlify.app";
   // const nextAppUrl = "http://localhost:3000";
 
   // Import jQuery into this file from CDN

--- a/signs-work-order-map/README.md
+++ b/signs-work-order-map/README.md
@@ -54,3 +54,10 @@ First-time setup: run `nvm use`, `npm install`, and `cp env_template .env` (add 
 2. Copy `knack/iframeMapMessenger.js` to a file named **`iframeMapMessengerDev.js`**.
 3. Upload **iframeMapMessengerDev.js** to the **atd-knack-signs-markings** S3 bucket under the **staging** prefix, replacing the existing file.  
    **Do not** change **iframeMapMessenger.js** in S3 (that is used for production).
+
+## Developer toolbox and one-time benchmarking tools
+
+- **Benchmark page (`/benchmark`)**: A developer-only page used to compare performance between rendering thousands of AGOL sign points as individual markers vs a single Mapbox circle layer.
+- **Benchmark utilities**: Implemented in `toolbox/benchmark/benchmarkUtils.ts`. These utilities set globals on `window` (ex: `getBenchmarkResults`, `exportBenchmarkResults`) and should **not** be wired into Knack or any production user flows.
+
+These tools are intended as **one-time / experimental** helpers to guide performance decisions. It is safe to refactor or remove them once they have served their purpose.

--- a/signs-work-order-map/README.md
+++ b/signs-work-order-map/README.md
@@ -4,19 +4,53 @@ This React app creates a geospatial picker that can display, drop, and edit loca
 
 Custom [javascript](https://github.com/cityofaustin/atd-knack-signs-markings/blob/21517-app-next/knack/index.js#L274) in the Knack application loads the iFrameMessenger script only on specific views.
 
-* Work Orders Details Page - Viewer: view_2619 (scene 1028)
-* Work Orders Details Page - Editable: view_2573 (scene 1028)
-* Location Details Page - Viewer & Editable: view_2733 (scene 1039)
-* Edit Location Page: view_2682 (scene 1061)
+- Work Orders Details Page - Viewer: view_2619 (scene 1028)
+- Work Orders Details Page - Editable: view_2573 (scene 1028)
+- Location Details Page - Viewer & Editable: view_2733 (scene 1039)
+- Edit Location Page: view_2682 (scene 1061)
 
-The iFrameMessenger script is in the `atd-knack-signs-markings` s3 bucket, in the staging folder. (There is no production folder.) The file is named `iframeMapMessenger.js`
+The iFrameMessenger script is in the `atd-knack-signs-markings` S3 bucket, in the staging folder. (There is no production folder.) The test Knack app loads **`iframeMapMessengerDev.js`** from that bucket; production uses **`iframeMapMessenger.js`**. Each script sets `nextAppUrl` to the React app that the iframe loads (Netlify deploy preview or localhost).
 
-The iFrameMessenger script has a [reference](https://github.com/cityofaustin/atd-knack-signs-markings/blob/staging/knack/iframeMapMessenger.js#L37) to the deployed react app on netlify. To recap, custom js in Knack points to the iFrameMessenger script in s3 which in turn specifies which deployed react app contains the map.
+# Testing a deploy preview in the Knack test environment
+
+To embed a Netlify deploy preview (ex: from a PR) in the Knack Signs and Markings **test** app, use the **`iframeMapMessengerDev.js`** file in S3 and point it at your preview URL.
+
+1. **Set the deploy preview URL in the repo (optional but recommended)**  
+   In your PR branch, edit `knack/iframeMapMessenger.js` and set the `nextAppUrl` constant (lines 10–11) to your deploy preview URL (ex: `https://deploy-preview-339--nextjs-knack-signs-markings.netlify.app`). This keeps version control in sync with what’s used in staging.
+
+2. **Prepare the dev messenger file**  
+   Download or copy `knack/iframeMapMessenger.js` and save it as **`iframeMapMessengerDev.js`** (with `nextAppUrl` set to your deploy preview URL).
+
+3. **Upload to S3**  
+   In [AWS S3](https://us-east-1.console.aws.amazon.com/s3/buckets/atd-knack-signs-markings?prefix=staging%2F&region=us-east-1&tab=objects), open the **atd-knack-signs-markings** bucket → **staging** prefix. Upload your **iframeMapMessengerDev.js** and replace the existing file (drag-and-drop and confirm).
+
+4. **Confirm the file in S3**  
+   Open the public URL and check that `nextAppUrl` is your deploy preview:  
+   [https://atd-knack-signs-markings.s3.us-east-1.amazonaws.com/staging/iframeMapMessengerDev.js](https://atd-knack-signs-markings.s3.us-east-1.amazonaws.com/staging/iframeMapMessengerDev.js)  
+   Knack will load this script and request your preview when the iframe loads.
+
+5. **Open the Knack test app & sign in**  
+   Go to the test instance, ex:  
+   [https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs). Use test credentials (ex: GIS QA).
+
+6. **Open an issued work order**
+
+   - Go to the Signs | Work Orders list:  
+     [https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/)
+   - Filter by **Issued** (third row of buttons above the table), or use this URL:  
+     [Work orders filtered by Issued](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/?view_2565_filters=%5B%7B%22text%22%3A%22Issued%22%2C%22field%22%3A%22field_3265%22%2C%22value%22%3A%22ISSUED%22%2C%22operator%22%3A%22is%22%7D%5D&view_2565_page=1)
+
+7. **View the embedded map**  
+   Click an issued work order to open its details page. Scroll down below the "Locations" section to see the embedded map.  
+   If the map doesn’t load, check the Dev Console for syntax errors in the JS file or issues executing the JS file when Knack page loads **iframeMapMessengerDev.js**.
 
 # Local Development
 
-In order to develop locally, use the "test-30-may-2024-signs-and-markings-operations" test application in Knack. That app uses the iFrameMessenger script in the file named `iframeMapMessengerDev.js`. If you want to work on the next js app locally while testing in the test Knack app, make a copy of the iframeMapMessenger.js file, save as `iframeMapMessengerDev.js` and update [this line](https://github.com/cityofaustin/atd-knack-signs-markings/blob/staging/knack/iframeMapMessenger.js#L37) such that the nextAppUrl is `"http://localhost:3000";`. Sign into s3 and replace the file with your copy. **Do not** update `iframeMapMessenger.js` because that is production.
+In order to develop locally, use a test application in Knack (ex: []"test-30-may-2024-signs-and-markings-operations"](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/?view_2565_filters=%5B%7B%22text%22%3A%22Issued%22%2C%22field%22%3A%22field_3265%22%2C%22value%22%3A%22ISSUED%22%2C%22operator%22%3A%22is%22%7D%5D&view_2565_page=1)).
 
-If this is your first time running locally, `nvm use` and `npm install` and `cp env_template .env`, fill out the mapbox token (look in 1Password).
+1. Copy `knack/iframeMapMessenger.js` to a file named **`iframeMapMessengerDev.js`**.
+2. Set `nextAppUrl` to `"http://localhost:3000"` in **iframeMapMessengerDev.js**.
+3. Upload **iframeMapMessengerDev.js** to the **atd-knack-signs-markings** S3 bucket under the **staging** prefix, replacing the existing file.  
+   **Do not** change **iframeMapMessenger.js** in S3 (that is used for production).
 
-Then `npm run dev` to get the app going on localhost:3000.
+First-time setup: run `nvm use`, `npm install`, and `cp env_template .env` (add your Mapbox token, ex: from 1Password). Then `npm run dev` to run the app at http://localhost:3000.

--- a/signs-work-order-map/README.md
+++ b/signs-work-order-map/README.md
@@ -48,9 +48,9 @@ To embed a Netlify deploy preview (ex: from a PR) in the Knack Signs and Marking
 
 In order to develop locally, use a test application in Knack (ex: []"test-30-may-2024-signs-and-markings-operations"](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/?view_2565_filters=%5B%7B%22text%22%3A%22Issued%22%2C%22field%22%3A%22field_3265%22%2C%22value%22%3A%22ISSUED%22%2C%22operator%22%3A%22is%22%7D%5D&view_2565_page=1)).
 
-1. Copy `knack/iframeMapMessenger.js` to a file named **`iframeMapMessengerDev.js`**.
-2. Set `nextAppUrl` to `"http://localhost:3000"` in **iframeMapMessengerDev.js**.
+First-time setup: run `nvm use`, `npm install`, and `cp env_template .env` (add your Mapbox token, ex: from 1Password). Then `npm run dev` to run the app at http://localhost:3000.
+
+1. Set `nextAppUrl` to `"http://localhost:3000"` in **iframeMapMessenger.js**.
+2. Copy `knack/iframeMapMessenger.js` to a file named **`iframeMapMessengerDev.js`**.
 3. Upload **iframeMapMessengerDev.js** to the **atd-knack-signs-markings** S3 bucket under the **staging** prefix, replacing the existing file.  
    **Do not** change **iframeMapMessenger.js** in S3 (that is used for production).
-
-First-time setup: run `nvm use`, `npm install`, and `cp env_template .env` (add your Mapbox token, ex: from 1Password). Then `npm run dev` to run the app at http://localhost:3000.

--- a/signs-work-order-map/app/benchmark/page.tsx
+++ b/signs-work-order-map/app/benchmark/page.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useState, useMemo, useRef, useCallback, useEffect } from "react";
+import MapGL, {
+  MapRef,
+  Marker,
+  NavigationControl,
+  Source,
+  Layer,
+  MapMouseEvent,
+} from "react-map-gl/mapbox";
+import type { CircleLayerSpecification } from "mapbox-gl";
+import {
+  generateMockSigns,
+  generateMockGeoJSON,
+  useMarkerPerformanceBenchmark,
+  useLayerPerformanceBenchmark,
+  setupBenchmarkConsoleUtils,
+} from "@/utils/benchmark";
+import {
+  DEFAULT_MAP_PARAMS,
+  DEFAULT_MAP_PAN_ZOOM,
+} from "@/config/map";
+
+// Initialize console utils on load
+if (typeof window !== "undefined") {
+  setupBenchmarkConsoleUtils();
+}
+
+type RenderMode = "markers" | "layer";
+
+const MARKER_COUNTS = [100, 500, 1000, 2000, 5000, 10000];
+
+// Layer style for AGOL signs (matching current marker appearance)
+const BENCHMARK_SOURCE_ID = "agol-signs";
+
+const agolSignsLayerStyle: CircleLayerSpecification = {
+  id: "agol-signs-layer",
+  type: "circle",
+  source: BENCHMARK_SOURCE_ID,
+  paint: {
+    "circle-radius": ["interpolate", ["linear"], ["zoom"], 14, 4, 18, 8],
+    "circle-color": "#FFD700", // Gold/Yellow
+    "circle-stroke-color": "#000000",
+    "circle-stroke-width": 1,
+  },
+};
+
+export default function BenchmarkPage() {
+  const mapRef = useRef<MapRef>(null);
+  const [renderMode, setRenderMode] = useState<RenderMode>("markers");
+  const [markerCount, setMarkerCount] = useState(500);
+  const [isRunning, setIsRunning] = useState(false);
+  const [currentCount, setCurrentCount] = useState(0);
+
+  // Generate mock data based on current count
+  const mockSigns = useMemo(() => {
+    if (renderMode === "markers" && currentCount > 0) {
+      return generateMockSigns(currentCount);
+    }
+    return [];
+  }, [currentCount, renderMode]);
+
+  const mockGeoJSON = useMemo(() => {
+    if (renderMode === "layer" && currentCount > 0) {
+      return generateMockGeoJSON(currentCount);
+    }
+    return { type: "FeatureCollection" as const, features: [] };
+  }, [currentCount, renderMode]);
+
+  // Benchmarking hooks
+  useMarkerPerformanceBenchmark(
+    renderMode === "markers" ? mockSigns.length : 0,
+    isRunning
+  );
+
+  useLayerPerformanceBenchmark(
+    renderMode === "layer" ? mockGeoJSON.features.length : 0,
+    "agol-signs-layer",
+    isRunning
+  );
+
+  const runBenchmark = useCallback(() => {
+    // Reset state
+    setCurrentCount(0);
+    setIsRunning(true);
+
+    // Small delay to ensure reset, then set count
+    setTimeout(() => {
+      setCurrentCount(markerCount);
+    }, 100);
+
+    // Stop after benchmark completes
+    setTimeout(() => {
+      setIsRunning(false);
+    }, 3000);
+  }, [markerCount]);
+
+  const clearMarkers = useCallback(() => {
+    setCurrentCount(0);
+    setIsRunning(false);
+  }, []);
+
+  // Marker rendering
+  const markers = useMemo(() => {
+    if (renderMode !== "markers") return null;
+
+    return mockSigns.map((sign) => (
+      <Marker
+        key={sign.id}
+        longitude={sign.lng}
+        latitude={sign.lat}
+      >
+        <div
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            backgroundColor: "#FFD700",
+            border: "1px solid #000000",
+            cursor: "pointer",
+            transform: "translate(-50%, -50%)",
+          }}
+        />
+      </Marker>
+    ));
+  }, [mockSigns, renderMode]);
+
+  const handleLayerClick = useCallback((e: MapMouseEvent) => {
+    if (e.features && e.features.length > 0) {
+      console.log("Clicked feature:", e.features[0].properties);
+    }
+  }, []);
+
+  return (
+    <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+      {/* Controls */}
+      <div
+        style={{
+          padding: "16px",
+          backgroundColor: "#f5f5f5",
+          borderBottom: "1px solid #ddd",
+          display: "flex",
+          gap: "16px",
+          alignItems: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        <div>
+          <label style={{ marginRight: "8px", fontWeight: "bold" }}>
+            Render Mode:
+          </label>
+          <select
+            value={renderMode}
+            onChange={(e) => {
+              setRenderMode(e.target.value as RenderMode);
+              clearMarkers();
+            }}
+            style={{ padding: "4px 8px" }}
+          >
+            <option value="markers">Individual Markers (Current)</option>
+            <option value="layer">GeoJSON Layer (Proposed)</option>
+          </select>
+        </div>
+
+        <div>
+          <label style={{ marginRight: "8px", fontWeight: "bold" }}>
+            Marker Count:
+          </label>
+          <select
+            value={markerCount}
+            onChange={(e) => setMarkerCount(Number(e.target.value))}
+            style={{ padding: "4px 8px" }}
+          >
+            {MARKER_COUNTS.map((count) => (
+              <option key={count} value={count}>
+                {count.toLocaleString()}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          onClick={runBenchmark}
+          disabled={isRunning}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: isRunning ? "#ccc" : "#007bff",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+            cursor: isRunning ? "not-allowed" : "pointer",
+          }}
+        >
+          {isRunning ? "Running..." : "Run Benchmark"}
+        </button>
+
+        <button
+          onClick={clearMarkers}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "#dc3545",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          Clear
+        </button>
+
+        <div
+          style={{
+            marginLeft: "auto",
+            padding: "8px 12px",
+            backgroundColor: "#fff",
+            borderRadius: "4px",
+            border: "1px solid #ddd",
+          }}
+        >
+          <strong>Current:</strong> {currentCount.toLocaleString()}{" "}
+          {renderMode === "markers" ? "markers" : "features"}
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <div
+        style={{
+          padding: "12px 16px",
+          backgroundColor: "#e7f3ff",
+          borderBottom: "1px solid #b8daff",
+          fontSize: "14px",
+        }}
+      >
+        <strong>Instructions:</strong> Select render mode and marker count, then
+        click "Run Benchmark". Open browser DevTools Console (F12) to see timing
+        results. Use <code>window.getBenchmarkResults()</code> to retrieve all
+        results, or <code>window.exportBenchmarkResults()</code> to export as
+        JSON.
+      </div>
+
+      {/* Map */}
+      <div style={{ flex: 1 }}>
+        <MapGL
+          ref={mapRef}
+          initialViewState={{
+            latitude: DEFAULT_MAP_PAN_ZOOM.latitude,
+            longitude: DEFAULT_MAP_PAN_ZOOM.longitude,
+            zoom: 17,
+          }}
+          {...DEFAULT_MAP_PARAMS}
+          interactiveLayerIds={renderMode === "layer" ? ["agol-signs-layer"] : []}
+          onClick={renderMode === "layer" ? handleLayerClick : undefined}
+        >
+          {/* Individual Markers (current approach) */}
+          {renderMode === "markers" && markers}
+
+          {/* GeoJSON Layer (proposed approach) */}
+          {renderMode === "layer" && currentCount > 0 && (
+            <Source id={BENCHMARK_SOURCE_ID} type="geojson" data={mockGeoJSON}>
+              <Layer {...agolSignsLayerStyle} />
+            </Source>
+          )}
+
+          <NavigationControl position="bottom-right" showCompass={false} />
+        </MapGL>
+      </div>
+    </div>
+  );
+}

--- a/signs-work-order-map/app/benchmark/page.tsx
+++ b/signs-work-order-map/app/benchmark/page.tsx
@@ -1,3 +1,15 @@
+/**
+ * ONE-TIME / EXPERIMENTAL TOOLING PAGE.
+ *
+ * This `/benchmark` route is a developer-only tool for comparing
+ * performance of individual markers vs a Mapbox circle layer when
+ * rendering large numbers of AGOL sign points.
+ *
+ * It is **not** part of any Knack iframe flow or production UX.
+ * Treat it as a throwaway experiment: safe to modify or delete once
+ * we are satisfied with the performance decisions it informed.
+ */
+
 "use client";
 
 import { useState, useMemo, useRef, useCallback, useEffect } from "react";
@@ -16,7 +28,7 @@ import {
   useMarkerPerformanceBenchmark,
   useLayerPerformanceBenchmark,
   setupBenchmarkConsoleUtils,
-} from "@/utils/benchmark";
+} from "@/toolbox/benchmark/benchmarkUtils";
 import {
   DEFAULT_MAP_PARAMS,
   DEFAULT_MAP_PAN_ZOOM,

--- a/signs-work-order-map/app/globals.scss
+++ b/signs-work-order-map/app/globals.scss
@@ -48,8 +48,8 @@ a {
  * Custom marker for ArcGIS Online sign assets displayed on the map
  */
 .agol-marker {
-  width: 8px;
-  height: 8px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   background-color: #ffd700; // Gold/Yellow color
   border: 1px solid #000000; // Black stroke

--- a/signs-work-order-map/app/globals.scss
+++ b/signs-work-order-map/app/globals.scss
@@ -90,13 +90,20 @@ a {
 }
 
 /**
- * Mapbox Popup Close Button Styles
+ * Mapbox Popup Customizations
  */
+
+//  Makes popup wider to accommodate title & X close button.
+// See: https://github.com/cityofaustin/atd-knack-signs-markings/pull/338#discussion_r2723053051
+.mapboxgl-popup {
+  min-width: 215px;
+}
+
 .mapboxgl-popup-close-button {
   color: #000000 !important;
   padding: 0.25rem 0.75rem 0.75rem 0.75rem;
   font-size: 1.5rem;
-  
+
   &:hover {
     color: #333333 !important;
   }

--- a/signs-work-order-map/app/globals.scss
+++ b/signs-work-order-map/app/globals.scss
@@ -88,3 +88,16 @@ a {
     color: #ffffff;
   }
 }
+
+/**
+ * Mapbox Popup Close Button Styles
+ */
+.mapboxgl-popup-close-button {
+  color: #000000 !important;
+  padding: 0.25rem 0.75rem 0.75rem 0.75rem;
+  font-size: 1.5rem;
+  
+  &:hover {
+    color: #333333 !important;
+  }
+}

--- a/signs-work-order-map/app/globals.scss
+++ b/signs-work-order-map/app/globals.scss
@@ -44,26 +44,6 @@ a {
 @import "../node_modules/bootstrap/scss/bootstrap";
 
 /**
- * AGOL Sign Marker Styles
- * Custom marker for ArcGIS Online sign assets displayed on the map
- */
-.agol-marker {
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background-color: #ffd700; // Gold/Yellow color
-  border: 1px solid #000000; // Black stroke
-  cursor: pointer;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3); // Subtle shadow for visibility
-  transform: translate(-50%, -50%); // Center the dot on the coordinate
-
-  &:hover {
-    transform: translate(-50%, -50%) scale(1.25);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
-  }
-}
-
-/**
  * Map Status Indicator Styles
  * Overlay indicators for loading and error states on the map
  */

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -209,6 +209,12 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
       {...DEFAULT_MAP_PARAMS}
       onDrag={updateCenterMarker}
       onZoom={updateCenterMarker}
+      onClick={(e) => {
+        // Close popup when clicking on the map (not on markers, which stop propagation)
+        if (popupInfo) {
+          setPopupInfo(null);
+        }
+      }}
       onMoveEnd={(e) => {
         updateCenterMarker(e);
         const moveEndZoom = e.viewState.zoom;

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -13,6 +13,9 @@ import MapGL, {
   ViewStateChangeEvent,
   NavigationControl,
   GeolocateControl,
+  Source,
+  Layer,
+  MapMouseEvent,
 } from "react-map-gl/mapbox";
 import GeocoderControl from "@/components/MapGeocoderControl";
 import SignPopup from "./SignPopup";
@@ -25,19 +28,21 @@ import {
   useGeoLocation,
   useAGOLSignAssets,
   getMapBounds,
+  agolFeatureToSign,
 } from "@/utils/mapUtils";
 import {
   DEFAULT_MAP_PARAMS,
   DEFAULT_MAP_PAN_ZOOM,
   MAP_COORDINATE_PRECISION,
   AGOL_SIGNS_MIN_ZOOM,
+  AGOL_SIGNS_LAYER_ID,
+  AGOL_SIGNS_SOURCE_ID,
+  AGOL_SIGNS_LAYER_STYLE,
 } from "@/config/map";
 
 /**
- *
  * @param signs Array of Signs from knack payload, or empty array
  * @param messageType String from knack payload
- * @returns
  */
 export default function Map({ signs, messageType, editLocation }: MapProps) {
   const mapRef = useRef<MapRef>(null);
@@ -100,30 +105,42 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
   // Only fetch AGOL signs when zoomed in enough for performance
   const isZoomedInEnough = zoom >= AGOL_SIGNS_MIN_ZOOM;
 
-  // Fetch AGOL sign assets based on current map bounds
+  // Fetch AGOL sign assets as GeoJSON for Layer rendering
   const {
-    agolSigns,
+    agolSignsGeoJSON,
     loading: agolLoading,
     error: agolError,
   } = useAGOLSignAssets(
     mapBounds,
-    mapLoaded && isZoomedInEnough // Only fetch when map is loaded and zoomed in enough
+    mapLoaded && isZoomedInEnough
   );
 
-  // Combine Knack signs with AGOL signs (only include AGOL signs if zoomed in enough)
-  const allSigns = useMemo(() => {
-    // Mark Knack signs with source
-    const knackSigns = signs.map((sign) => ({
-      ...sign,
-      source: "knack" as const,
-    }));
-    // Only include AGOL signs when zoomed in enough for performance
-    const visibleAgolSigns = isZoomedInEnough ? agolSigns : [];
+  const knackSigns = useMemo(
+    () => signs.map((sign) => ({ ...sign, source: "knack" as const })),
+    [signs]
+  );
+  const signPins = useCreateSignPins(knackSigns, setPopupInfo);
 
-    return [...knackSigns, ...visibleAgolSigns];
-  }, [signs, agolSigns, isZoomedInEnough]);
+  const handleMouseEnter = useCallback(() => {
+    if (mapRef.current) {
+      mapRef.current.getCanvas().style.cursor = "pointer";
+    }
+  }, []);
 
-  const signPins = useCreateSignPins(allSigns, setPopupInfo);
+  const handleMouseLeave = useCallback(() => {
+    if (mapRef.current) {
+      mapRef.current.getCanvas().style.cursor = "";
+    }
+  }, []);
+
+  const handleAGOLLayerClick = useCallback(
+    (e: MapMouseEvent) => {
+      if (!e.features || e.features.length === 0) return;
+      const sign = agolFeatureToSign(e.features[0]);
+      if (sign) setPopupInfo(sign);
+    },
+    [setPopupInfo]
+  );
 
   /**
    * Derive the initial map center position based on editLocation or geoLocation.
@@ -207,13 +224,17 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
       }}
       cooperativeGestures={true}
       {...DEFAULT_MAP_PARAMS}
+      interactiveLayerIds={isZoomedInEnough ? [AGOL_SIGNS_LAYER_ID] : []}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       onDrag={updateCenterMarker}
       onZoom={updateCenterMarker}
       onClick={(e) => {
-        // Close popup when clicking on the map (not on markers, which stop propagation)
-        if (popupInfo) {
-          setPopupInfo(null);
+        if (e.features && e.features.length > 0) {
+          handleAGOLLayerClick(e);
+          return;
         }
+        if (popupInfo) setPopupInfo(null);
       }}
       onMoveEnd={(e) => {
         updateCenterMarker(e);
@@ -244,6 +265,13 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
       }
 
       {signPins}
+
+      {isZoomedInEnough && agolSignsGeoJSON.features.length > 0 && (
+        <Source id={AGOL_SIGNS_SOURCE_ID} type="geojson" data={agolSignsGeoJSON}>
+          <Layer {...AGOL_SIGNS_LAYER_STYLE} />
+        </Source>
+      )}
+
       {popupInfo && (
         <SignPopup popupInfo={popupInfo} setPopupInfo={setPopupInfo} />
       )}

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -10,15 +10,15 @@ interface SignPopupProps {
 export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
   // Check if this is an AGOL sign
   const isAGOLSign = popupInfo.source === "agol";
-  
+
   // Extract AGOL-specific fields
-  const assetLocationId = isAGOLSign 
-    ? popupInfo.attributes?.ASSET_LOCATION_ID 
+  const assetLocationId = isAGOLSign
+    ? popupInfo.attributes?.ASSET_LOCATION_ID
     : null;
   const signMessagesAtLocation = isAGOLSign
     ? popupInfo.attributes?.SIGN_MESSAGES_AT_LOCATION
     : null;
-  
+
   // Split sign messages by comma and filter out empty strings
   const signMessagesList = signMessagesAtLocation
     ? String(signMessagesAtLocation)
@@ -46,7 +46,9 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
             {assetLocationId != null && (
               <div className="mb-0 mt-2 d-flex align-items-center">
                 <span className="fw-bold me-2">Location ID:</span>
-                <span className="text-muted mb-0">{String(assetLocationId)}</span>
+                <span className="text-muted mb-0">
+                  {String(assetLocationId)}
+                </span>
               </div>
             )}
             {signMessagesList.length > 0 && (
@@ -63,7 +65,9 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
               </div>
             )}
             {signMessagesList.length === 0 && assetLocationId == null && (
-              <div className="text-muted">No additional information available</div>
+              <div className="text-muted">
+                No additional information available
+              </div>
             )}
           </div>
         </div>

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -41,7 +41,7 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
         <div className="h-100 nav-tile card border-0">
           <div className="card-body p-2">
             <div className="fw-bold fs-6 pb-2 border-bottom card-title h5">
-              Exisiting sign details
+              Existing sign details
             </div>
             {assetLocationId != null && (
               <div className="mb-0 mt-2 d-flex align-items-center">

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -33,7 +33,7 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
       longitude={popupInfo.lng}
       latitude={popupInfo.lat}
       onClose={() => setPopupInfo(null)}
-      offset={[-5, 1]}
+      offset={[-8, 0]}
       maxWidth="300px"
     >
       {isAGOLSign ? (

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -53,7 +53,7 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
             )}
             {signMessagesList.length > 0 && (
               <div className="mt-2">
-                <div className="fw-bold mb-1">Exisiting signs:</div>
+                <div className="fw-bold mb-1">Existing signs:</div>
                 <div className="text-muted">
                   {signMessagesList.map((message, index) => (
                     <div key={index}>

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -8,7 +8,25 @@ interface SignPopupProps {
 }
 
 export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
-  // prod has the font as bold, do we keep?
+  // Check if this is an AGOL sign
+  const isAGOLSign = popupInfo.source === "agol";
+  
+  // Extract AGOL-specific fields
+  const assetLocationId = isAGOLSign 
+    ? popupInfo.attributes?.ASSET_LOCATION_ID 
+    : null;
+  const signMessagesAtLocation = isAGOLSign
+    ? popupInfo.attributes?.SIGN_MESSAGES_AT_LOCATION
+    : null;
+  
+  // Split sign messages by comma and filter out empty strings
+  const signMessagesList = signMessagesAtLocation
+    ? String(signMessagesAtLocation)
+        .split(",")
+        .map((msg) => msg.trim())
+        .filter((msg) => msg.length > 0)
+    : [];
+
   return (
     <Popup
       anchor="top"
@@ -16,25 +34,60 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
       latitude={popupInfo.lat}
       onClose={() => setPopupInfo(null)}
       offset={[0, -20]}
+      maxWidth="300px"
     >
-      <ul className="list-unstyled m-0">
-        {!popupInfo.isLocationDetailPage && (
-          <li>
-            <a
-              href={`${KNACK_APP_URL}#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
-                popupInfo.id
-              }`}
-              // ensure it doesn't open in the iframe
-              target="_top"
-            >
-              Location Detail Page
-            </a>
-          </li>
-        )}
-        <li>Spatial ID: {popupInfo.spatialId}</li>
-        <li>Latitude: {popupInfo.lat}</li>
-        <li>Longitude: {popupInfo.lng}</li>
-      </ul>
+      {isAGOLSign ? (
+        // AGOL sign popup content with card styling
+        <div className="h-100 nav-tile card border-0">
+          <div className="card-body p-2">
+            <div className="fw-bold fs-6 pb-2 border-bottom card-title h5">
+              Exisiting sign details
+            </div>
+            {assetLocationId != null && (
+              <div className="mb-0 mt-2 d-flex align-items-center">
+                <span className="fw-bold me-2">Location ID:</span>
+                <span className="text-muted mb-0">{String(assetLocationId)}</span>
+              </div>
+            )}
+            {signMessagesList.length > 0 && (
+              <div className="mt-2">
+                <div className="fw-bold mb-1">Exisiting signs:</div>
+                <div className="text-muted">
+                  {signMessagesList.map((message, index) => (
+                    <div key={index}>
+                      {message}
+                      {index < signMessagesList.length - 1 && ","}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {signMessagesList.length === 0 && assetLocationId == null && (
+              <div className="text-muted">No additional information available</div>
+            )}
+          </div>
+        </div>
+      ) : (
+        // Knack sign popup content (existing behavior)
+        <ul className="list-unstyled m-0">
+          {!popupInfo.isLocationDetailPage && (
+            <li>
+              <a
+                href={`${KNACK_APP_URL}#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
+                  popupInfo.id
+                }`}
+                // ensure it doesn't open in the iframe
+                target="_top"
+              >
+                Location Detail Page
+              </a>
+            </li>
+          )}
+          <li>Spatial ID: {popupInfo.spatialId}</li>
+          <li>Latitude: {popupInfo.lat}</li>
+          <li>Longitude: {popupInfo.lng}</li>
+        </ul>
+      )}
     </Popup>
   );
 }

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -46,14 +46,14 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
     >
       {isAGOLSign ? (
         // AGOL sign popup content with card styling
-        <div className="h-100 nav-tile card border-0">
+        <div className="h-100 nav-tile card border-0 fs-6">
           <div className="card-body p-2">
-            <div className="fw-bold fs-6 pb-2 border-bottom card-title h5">
+            {/* <div className="fw-bold fs-6 pb-2 border-bottom card-title h5">
               Existing sign details
-            </div>
+            </div> */}
             {assetLocationId != null && (
               <div className="mb-0 mt-2 d-flex align-items-center">
-                <span className="fw-bold me-2">Location ID:</span>
+                <span className="fw-bold me-2">Location ID</span>
                 <span className="text-muted mb-0">
                   {String(assetLocationId)}
                 </span>
@@ -61,17 +61,24 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
             )}
             {signMessagesList.length > 0 && (
               <div className="mt-2">
-                <div className="fw-bold mb-1">Existing signs:</div>
-                <div className="text-muted">
+                {/* <div className="fw-bold mb-1">Existing signs</div> */}
+                <ul className="list-group list-group-flush">
                   {Array.from(signMessageCounts.entries()).map(
                     ([message, count]) => (
-                      <div key={message}>
+                      <li
+                        key={message}
+                        className="list-group-item px-0 py-3 fs-6"
+                      >
                         {message}
-                        {count > 1 && ` (x${count})`}
-                      </div>
+                        {count > 1 && (
+                          <span className="badge border text-dark bg-light ms-2">
+                            x {count}
+                          </span>
+                        )}
+                      </li>
                     )
                   )}
-                </div>
+                </ul>
               </div>
             )}
             {signMessagesList.length === 0 && assetLocationId == null && (

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -33,7 +33,7 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
       longitude={popupInfo.lng}
       latitude={popupInfo.lat}
       onClose={() => setPopupInfo(null)}
-      offset={[0, -20]}
+      offset={[-5, 1]}
       maxWidth="300px"
     >
       {isAGOLSign ? (

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -27,6 +27,13 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
         .filter((msg) => msg.length > 0)
     : [];
 
+  // Group identical sign messages and count occurrences:
+  const signMessageCounts = new Map<string, number>();
+  signMessagesList.forEach((message) => {
+    const current = signMessageCounts.get(message) ?? 0;
+    signMessageCounts.set(message, current + 1);
+  });
+
   return (
     <Popup
       anchor="top"
@@ -55,12 +62,14 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
               <div className="mt-2">
                 <div className="fw-bold mb-1">Existing signs:</div>
                 <div className="text-muted">
-                  {signMessagesList.map((message, index) => (
-                    <div key={index}>
-                      {message}
-                      {index < signMessagesList.length - 1 && ","}
-                    </div>
-                  ))}
+                  {Array.from(signMessageCounts.entries()).map(
+                    ([message, count]) => (
+                      <div key={message}>
+                        {message}
+                        {count > 1 && ` (x${count})`}
+                      </div>
+                    )
+                  )}
                 </div>
               </div>
             )}

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -40,7 +40,8 @@ export default function SignPopup({ popupInfo, setPopupInfo }: SignPopupProps) {
       longitude={popupInfo.lng}
       latitude={popupInfo.lat}
       onClose={() => setPopupInfo(null)}
-      offset={[-8, 0]}
+      closeOnClick={false}
+      offset={[0, 6]}
       maxWidth="300px"
     >
       {isAGOLSign ? (

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -23,7 +23,7 @@ export const DEFAULT_MAP_PAN_ZOOM = {
  * Minimum zoom level required to display AGOL sign assets
  * Zoom levels below this threshold will hide signs to improve performance
  */
-export const AGOL_SIGNS_MIN_ZOOM = 16.75;
+export const AGOL_SIGNS_MIN_ZOOM = 15.5;
 
 /** Mapbox source and layer ids for the AGOL signs GeoJSON layer */
 export const AGOL_SIGNS_SOURCE_ID = "agol-signs";
@@ -38,10 +38,26 @@ export const AGOL_SIGNS_LAYER_STYLE: CircleLayerSpecification = {
   type: "circle",
   source: AGOL_SIGNS_SOURCE_ID,
   paint: {
-    "circle-radius": 8,
-    "circle-color": "#FFD700",
-    "circle-stroke-color": "#000000",
-    "circle-stroke-width": 1,
+    // Interpolate radius by zoom so points get larger
+    // (and easier to tap) as you zoom in.
+    "circle-radius": [
+      "interpolate",
+      ["linear"],
+      ["zoom"],
+      // Just above min zoom for signs
+      15,
+      6,
+      // Very close in
+      20,
+      18,
+    ],
+    // Base fill color; tuned for contrast over aerial imagery.
+    "circle-color": "#00FFFF",
+    // White stroke to improve contrast between overlapping points
+    // and against dark / light aerial backgrounds.
+    "circle-stroke-color": "#FFFFFF",
+    // Thicker stroke at higher zoom to match larger circles
+    "circle-stroke-width": ["interpolate", ["linear"], ["zoom"], 15, 1, 20, 4],
   },
 };
 

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -1,4 +1,5 @@
 import "mapbox-gl/dist/mapbox-gl.css";
+import type { CircleLayerSpecification } from "mapbox-gl";
 // import { SymbolLayerSpecification, RasterLayerSpecification } from "mapbox-gl";
 
 // // The Nearmap API key is managed by CTM. Contact help desk for maintenance and troubleshooting.
@@ -23,6 +24,26 @@ export const DEFAULT_MAP_PAN_ZOOM = {
  * Zoom levels below this threshold will hide signs to improve performance
  */
 export const AGOL_SIGNS_MIN_ZOOM = 16.75;
+
+/** Mapbox source and layer ids for the AGOL signs GeoJSON layer */
+export const AGOL_SIGNS_SOURCE_ID = "agol-signs";
+export const AGOL_SIGNS_LAYER_ID = "agol-signs-layer";
+
+/**
+ * Mapbox circle layer style for AGOL sign points.
+ * Single WebGL layer for performance; radius tuned for touch (e.g. iPad).
+ */
+export const AGOL_SIGNS_LAYER_STYLE: CircleLayerSpecification = {
+  id: AGOL_SIGNS_LAYER_ID,
+  type: "circle",
+  source: AGOL_SIGNS_SOURCE_ID,
+  paint: {
+    "circle-radius": 8,
+    "circle-color": "#FFD700",
+    "circle-stroke-color": "#000000",
+    "circle-stroke-width": 1,
+  },
+};
 
 export const MAP_MAX_BOUNDS: [[number, number], [number, number]] = [
   [-99, 29],

--- a/signs-work-order-map/toolbox/benchmark/benchmarkUtils.ts
+++ b/signs-work-order-map/toolbox/benchmark/benchmarkUtils.ts
@@ -1,9 +1,18 @@
 /**
- * Performance benchmarking utilities for map marker vs layer rendering.
+ * ONE-TIME / EXPERIMENTAL TOOLING — NOT PART OF THE CORE APP.
  *
- * Usage: Import useMarkerPerformanceBenchmark / useLayerPerformanceBenchmark
- * in Map or the benchmark page; open DevTools Console to see results.
- * Use window.getBenchmarkResults() or window.exportBenchmarkResults() to export.
+ * These utilities exist only to benchmark different rendering approaches
+ * (individual markers vs a Mapbox circle layer) for AGOL sign data.
+ *
+ * They should only be used from the `/benchmark` route in local/dev
+ * environments to inform performance decisions. They are not intended
+ * to run in Knack iframes or any production user flows.
+ *
+ * Usage:
+ * - See `app/benchmark/page.tsx` for the dedicated benchmark page.
+ * - Open DevTools Console to view results.
+ * - Use `window.getBenchmarkResults()` or
+ *   `window.exportBenchmarkResults()` to export history as JSON.
  */
 
 import { useEffect, useRef } from "react";
@@ -114,10 +123,15 @@ export const useMarkerPerformanceBenchmark = (
           timestamp: new Date().toISOString(),
         };
         console.log("📊 MARKER BENCHMARK", result);
-        (window as unknown as { __lastBenchmark?: BenchmarkResult }).__lastBenchmark = result;
-        (window as unknown as { __benchmarkHistory?: BenchmarkResult[] }).__benchmarkHistory =
-          (window as unknown as { __benchmarkHistory?: BenchmarkResult[] }).__benchmarkHistory || [];
-        (window as unknown as { __benchmarkHistory: BenchmarkResult[] }).__benchmarkHistory.push(result);
+        (window as unknown as { __lastBenchmark?: BenchmarkResult }).__lastBenchmark =
+          result;
+        (window as unknown as { __benchmarkHistory?: BenchmarkResult[] })
+          .__benchmarkHistory =
+          (window as unknown as { __benchmarkHistory?: BenchmarkResult[] })
+            .__benchmarkHistory || [];
+        (window as unknown as { __benchmarkHistory: BenchmarkResult[] }).__benchmarkHistory.push(
+          result
+        );
         hasLoggedRef.current = signCount;
         startTimeRef.current = null;
       }, 100);
@@ -164,10 +178,15 @@ export const useLayerPerformanceBenchmark = (
           timestamp: new Date().toISOString(),
         };
         console.log("📊 LAYER BENCHMARK", result);
-        (window as unknown as { __lastLayerBenchmark?: BenchmarkResult }).__lastLayerBenchmark = result;
-        (window as unknown as { __layerBenchmarkHistory?: BenchmarkResult[] }).__layerBenchmarkHistory =
-          (window as unknown as { __layerBenchmarkHistory?: BenchmarkResult[] }).__layerBenchmarkHistory || [];
-        (window as unknown as { __layerBenchmarkHistory: BenchmarkResult[] }).__layerBenchmarkHistory.push(result);
+        (window as unknown as { __lastLayerBenchmark?: BenchmarkResult }).__lastLayerBenchmark =
+          result;
+        (window as unknown as { __layerBenchmarkHistory?: BenchmarkResult[] })
+          .__layerBenchmarkHistory =
+          (window as unknown as { __layerBenchmarkHistory?: BenchmarkResult[] })
+            .__layerBenchmarkHistory || [];
+        (window as unknown as { __layerBenchmarkHistory: BenchmarkResult[] }).__layerBenchmarkHistory.push(
+          result
+        );
         hasLoggedRef.current = featureCount;
         startTimeRef.current = null;
       }, 100);
@@ -179,7 +198,10 @@ export const useLayerPerformanceBenchmark = (
 export const setupBenchmarkConsoleUtils = () => {
   if (typeof window === "undefined") return;
   const w = window as unknown as {
-    getBenchmarkResults?: () => { marker: BenchmarkResult[]; layer: BenchmarkResult[] };
+    getBenchmarkResults?: () => {
+      marker: BenchmarkResult[];
+      layer: BenchmarkResult[];
+    };
     clearBenchmarkHistory?: () => void;
     exportBenchmarkResults?: () => string;
     __benchmarkHistory?: BenchmarkResult[];
@@ -200,3 +222,4 @@ export const setupBenchmarkConsoleUtils = () => {
     return json;
   };
 };
+

--- a/signs-work-order-map/utils/agol.ts
+++ b/signs-work-order-map/utils/agol.ts
@@ -35,10 +35,7 @@ interface AGOLFeature {
   properties: {
     [key: string]: unknown;
   };
-  geometry: {
-    type: string;
-    coordinates: number[];
-  };
+  geometry: GeoJSON.Point;
 }
 
 interface FeatureCollection {

--- a/signs-work-order-map/utils/benchmark.ts
+++ b/signs-work-order-map/utils/benchmark.ts
@@ -1,0 +1,202 @@
+/**
+ * Performance benchmarking utilities for map marker vs layer rendering.
+ *
+ * Usage: Import useMarkerPerformanceBenchmark / useLayerPerformanceBenchmark
+ * in Map or the benchmark page; open DevTools Console to see results.
+ * Use window.getBenchmarkResults() or window.exportBenchmarkResults() to export.
+ */
+
+import { useEffect, useRef } from "react";
+
+export interface BenchmarkResult {
+  signCount: number;
+  initialRenderMs: number;
+  memoryUsageMB: number | null;
+  domElementCount: number;
+  timestamp: string;
+}
+
+export const generateMockSigns = (
+  count: number,
+  centerLat = 30.28,
+  centerLng = -97.7506
+): Array<{
+  id: string;
+  lat: number;
+  lng: number;
+  spatialId: number;
+  workOrderId: string;
+  isLocationDetailPage: boolean;
+  source: "agol";
+  attributes: Record<string, unknown>;
+}> => {
+  const signs = [];
+  const gridSize = Math.ceil(Math.sqrt(count));
+  const spacing = 0.0002;
+
+  for (let i = 0; i < count; i++) {
+    const row = Math.floor(i / gridSize);
+    const col = i % gridSize;
+    const lat = centerLat + (row - gridSize / 2) * spacing;
+    const lng = centerLng + (col - gridSize / 2) * spacing;
+    signs.push({
+      id: `mock-agol-${i}`,
+      lat,
+      lng,
+      spatialId: 100000 + i,
+      workOrderId: "",
+      isLocationDetailPage: false,
+      source: "agol" as const,
+      attributes: { OBJECTID_1: 100000 + i, ASSET_LOC_ID: `MOCK-${i}` },
+    });
+  }
+  return signs;
+};
+
+export const generateMockGeoJSON = (
+  count: number,
+  centerLat = 30.28,
+  centerLng = -97.7506
+): GeoJSON.FeatureCollection<GeoJSON.Point> => {
+  const gridSize = Math.ceil(Math.sqrt(count));
+  const spacing = 0.0002;
+  const features: GeoJSON.Feature<GeoJSON.Point>[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const row = Math.floor(i / gridSize);
+    const col = i % gridSize;
+    const lat = centerLat + (row - gridSize / 2) * spacing;
+    const lng = centerLng + (col - gridSize / 2) * spacing;
+    features.push({
+      type: "Feature",
+      properties: { OBJECTID_1: 100000 + i, ASSET_LOC_ID: `MOCK-${i}` },
+      geometry: { type: "Point", coordinates: [lng, lat] },
+    });
+  }
+  return { type: "FeatureCollection", features };
+};
+
+export const useMarkerPerformanceBenchmark = (
+  signCount: number,
+  enabled: boolean = false
+) => {
+  const startTimeRef = useRef<number | null>(null);
+  const hasLoggedRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!enabled || signCount === 0) return;
+    if (startTimeRef.current === null) startTimeRef.current = performance.now();
+  }, [signCount, enabled]);
+
+  useEffect(() => {
+    if (!enabled || signCount === 0 || signCount === hasLoggedRef.current)
+      return;
+    const rafId = requestAnimationFrame(() => {
+      setTimeout(() => {
+        const endTime = performance.now();
+        const renderTime = startTimeRef.current
+          ? endTime - startTimeRef.current
+          : 0;
+        const markerEls = document.querySelectorAll(".agol-marker").length;
+        const mapboxMarkers = document.querySelectorAll(".mapboxgl-marker").length;
+        let memoryMB: number | null = null;
+        if ("memory" in performance) {
+          memoryMB =
+            (performance as unknown as { memory: { usedJSHeapSize: number } })
+              .memory.usedJSHeapSize /
+            (1024 * 1024);
+        }
+        const result: BenchmarkResult = {
+          signCount,
+          initialRenderMs: Math.round(renderTime * 100) / 100,
+          memoryUsageMB: memoryMB ? Math.round(memoryMB * 100) / 100 : null,
+          domElementCount: markerEls + mapboxMarkers,
+          timestamp: new Date().toISOString(),
+        };
+        console.log("📊 MARKER BENCHMARK", result);
+        (window as unknown as { __lastBenchmark?: BenchmarkResult }).__lastBenchmark = result;
+        (window as unknown as { __benchmarkHistory?: BenchmarkResult[] }).__benchmarkHistory =
+          (window as unknown as { __benchmarkHistory?: BenchmarkResult[] }).__benchmarkHistory || [];
+        (window as unknown as { __benchmarkHistory: BenchmarkResult[] }).__benchmarkHistory.push(result);
+        hasLoggedRef.current = signCount;
+        startTimeRef.current = null;
+      }, 100);
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [signCount, enabled]);
+};
+
+export const useLayerPerformanceBenchmark = (
+  featureCount: number,
+  _layerId: string,
+  enabled: boolean = false
+) => {
+  const startTimeRef = useRef<number | null>(null);
+  const hasLoggedRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!enabled || featureCount === 0) return;
+    if (startTimeRef.current === null) startTimeRef.current = performance.now();
+  }, [featureCount, enabled]);
+
+  useEffect(() => {
+    if (!enabled || featureCount === 0 || featureCount === hasLoggedRef.current)
+      return;
+    const rafId = requestAnimationFrame(() => {
+      setTimeout(() => {
+        const endTime = performance.now();
+        const renderTime = startTimeRef.current
+          ? endTime - startTimeRef.current
+          : 0;
+        const markerEls = document.querySelectorAll(".agol-marker").length;
+        let memoryMB: number | null = null;
+        if ("memory" in performance) {
+          memoryMB =
+            (performance as unknown as { memory: { usedJSHeapSize: number } })
+              .memory.usedJSHeapSize /
+            (1024 * 1024);
+        }
+        const result: BenchmarkResult = {
+          signCount: featureCount,
+          initialRenderMs: Math.round(renderTime * 100) / 100,
+          memoryUsageMB: memoryMB ? Math.round(memoryMB * 100) / 100 : null,
+          domElementCount: markerEls,
+          timestamp: new Date().toISOString(),
+        };
+        console.log("📊 LAYER BENCHMARK", result);
+        (window as unknown as { __lastLayerBenchmark?: BenchmarkResult }).__lastLayerBenchmark = result;
+        (window as unknown as { __layerBenchmarkHistory?: BenchmarkResult[] }).__layerBenchmarkHistory =
+          (window as unknown as { __layerBenchmarkHistory?: BenchmarkResult[] }).__layerBenchmarkHistory || [];
+        (window as unknown as { __layerBenchmarkHistory: BenchmarkResult[] }).__layerBenchmarkHistory.push(result);
+        hasLoggedRef.current = featureCount;
+        startTimeRef.current = null;
+      }, 100);
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [featureCount, _layerId, enabled]);
+};
+
+export const setupBenchmarkConsoleUtils = () => {
+  if (typeof window === "undefined") return;
+  const w = window as unknown as {
+    getBenchmarkResults?: () => { marker: BenchmarkResult[]; layer: BenchmarkResult[] };
+    clearBenchmarkHistory?: () => void;
+    exportBenchmarkResults?: () => string;
+    __benchmarkHistory?: BenchmarkResult[];
+    __layerBenchmarkHistory?: BenchmarkResult[];
+  };
+  w.getBenchmarkResults = () => ({
+    marker: w.__benchmarkHistory || [],
+    layer: w.__layerBenchmarkHistory || [],
+  });
+  w.clearBenchmarkHistory = () => {
+    w.__benchmarkHistory = [];
+    w.__layerBenchmarkHistory = [];
+    console.log("Benchmark history cleared");
+  };
+  w.exportBenchmarkResults = () => {
+    const json = JSON.stringify(w.getBenchmarkResults?.() ?? {}, null, 2);
+    console.log(json);
+    return json;
+  };
+};

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -183,7 +183,7 @@ export const useAGOLSignAssets = (
  * Converts a GeoJSON point feature from the AGOL layer (e.g. from map click) into a Sign
  * for use in the popup.
  *
- * @param feature Clicked feature with Point geometry and AGOL properties (OBJECTID_1, etc.)
+ * @param feature Clicked GeoJSON point feature with AGOL properties (OBJECTID_1, etc.)
  * @returns Sign for popup, or null if feature is invalid
  */
 export function agolFeatureToSign(feature: unknown): Sign | null {

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,14 +1,11 @@
-import { useEffect, useMemo, useState, startTransition } from "react";
+import { useEffect, useMemo, useState } from "react";
 import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
 import { LngLatBoundsLike } from "mapbox-gl";
 import { Marker } from "react-map-gl/mapbox";
 import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
 import { MAP_COORDINATE_PRECISION } from "@/config/map";
-import {
-  useSignAssetsFeatureService,
-  convertGeoJSONToSigns,
-} from "@/utils/agol";
+import { useSignAssetsFeatureService } from "@/utils/agol";
 
 /**
  * Takes array of Signs from knack payload and if signs exist, returns bounding box for signs
@@ -96,29 +93,14 @@ export const useFormatLocation = (
   }, [knackPayload]);
 
 /**
- * Custom marker component for AGOL signs (yellow dots with black stroke)
- * Styles are defined in globals.scss (.agol-marker)
- */
-const AGOLMarker = ({
-  onClick,
-}: {
-  onClick: (e: React.MouseEvent<HTMLDivElement>) => void;
-}) => <div onClick={onClick} className="agol-marker" />;
-
-
-/**
- * Takes array of Signs and returns array of map markers, one marker per sign
+ * Takes array of Knack Signs and returns array of map markers.
+ * AGOL signs are rendered via a GeoJSON Layer in Map.tsx for performance.
  *
  * Marker color logic:
  * - Red: Location detail page sign (isLocationDetailPage = true)
- * - Default blue: Knack work order signs (source = "knack" or undefined)
- * - Yellow dot: AGOL signs (source = "agol", uses custom AGOLMarker component)
+ * - Default blue: Knack work order signs
  *
- * Interaction logic:
- * - Knack signs: Show popup with work order info when clicked
- * - AGOL signs: Show popup with asset location ID and sign messages when clicked (handled by AGOLMarker)
- *
- * @param signs Array of Signs (can include both Knack and AGOL signs)
+ * @param signs Array of Knack Signs
  * @param setPopupInfo State setter for popup display
  * @returns Array of Map Markers
  */
@@ -136,31 +118,12 @@ export const useCreateSignPins = (
               key={`marker-${sign.id}`}
               longitude={sign.lng}
               latitude={sign.lat}
-              // Only override color for location detail page (red)
-              // All other signs use default color (AGOL uses custom marker component anyway)
               color={sign.isLocationDetailPage ? "red" : undefined}
               onClick={(e) => {
-                // Only handle clicks for non-AGOL signs here
-                // AGOL signs are handled by their custom AGOLMarker component
-                if (sign.source !== "agol") {
-                  // If we let the click event propagates to the map, it will immediately close the popup
-                  // with `closeOnClick: true`
-                  e.originalEvent.stopPropagation();
-                  setPopupInfo(sign);
-                }
+                e.originalEvent.stopPropagation();
+                setPopupInfo(sign);
               }}
-            >
-              {/* Custom marker for AGOL signs */}
-              {sign.source === "agol" && (
-                <AGOLMarker
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    // Show popup for AGOL signs
-                    setPopupInfo(sign);
-                  }}
-                />
-              )}
-            </Marker>
+            />
           )
       ),
     [signs, setPopupInfo]
@@ -187,10 +150,12 @@ export const useGeoLocation = () => {
 };
 
 /**
- * Custom hook to fetch AGOL sign assets based on map bounds
+ * Custom hook to fetch AGOL sign assets based on map bounds.
+ * Returns GeoJSON for use with MapGL Source/Layer (single WebGL layer, better performance).
+ *
  * @param bounds Current map bounds
  * @param enabled Whether to fetch data (useful for disabling during initial load)
- * @returns Object containing AGOL signs, loading state, and error state
+ * @returns Object containing GeoJSON FeatureCollection, loading state, and error state
  */
 export const useAGOLSignAssets = (
   bounds: { north: number; south: number; east: number; west: number } | null,
@@ -199,7 +164,6 @@ export const useAGOLSignAssets = (
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Use the feature service hook with GeoJSON accumulation
   const geojson = useSignAssetsFeatureService(
     bounds,
     enabled,
@@ -207,37 +171,53 @@ export const useAGOLSignAssets = (
     setError
   );
 
-  // Convert GeoJSON to Sign array format for compatibility
-  const { agolSigns, conversionError } = useMemo(() => {
-    try {
-      return {
-        agolSigns: convertGeoJSONToSigns(geojson),
-        conversionError: null,
-      };
-    } catch (err) {
-      console.error("Error converting AGOL GeoJSON to signs:", err);
-      const errorMessage =
-        err instanceof Error ? err.message : "Unknown error occurred";
-      return { agolSigns: [], conversionError: errorMessage };
-    }
-  }, [geojson]);
-
-  // Handle conversion error in an effect to avoid setState during render
-  // Using startTransition to mark this as a non-urgent update
-  useEffect(() => {
-    if (conversionError && !error) {
-      startTransition(() => {
-        setError(conversionError);
-      });
-    }
-  }, [conversionError, error]);
-
   return {
-    agolSigns,
+    agolSignsGeoJSON: geojson,
+    featureCount: geojson.features.length,
     loading,
     error,
   };
 };
+
+/**
+ * Converts a GeoJSON point feature from the AGOL layer (e.g. from map click) into a Sign
+ * for use in the popup. Keeps conversion logic in one place for reviewers and reuse.
+ *
+ * @param feature Clicked feature with Point geometry and AGOL properties (OBJECTID_1, etc.)
+ * @returns Sign for popup, or null if feature is invalid
+ */
+export function agolFeatureToSign(feature: unknown): Sign | null {
+  const f = feature as {
+    properties?: Record<string, unknown> | null;
+    geometry?: { type: string; coordinates?: unknown };
+  };
+  const { properties, geometry } = f;
+  if (
+    !geometry ||
+    geometry.type !== "Point" ||
+    !Array.isArray(geometry.coordinates) ||
+    geometry.coordinates.length < 2
+  ) {
+    return null;
+  }
+  if (!properties) return null;
+
+  const [lng, lat] = geometry.coordinates as [number, number];
+  const objectId = properties.OBJECTID_1;
+  const spatialId =
+    typeof objectId === "number" ? objectId : Number(objectId) || 0;
+
+  return {
+    id: `agol-${spatialId}`,
+    lng,
+    lat,
+    spatialId,
+    workOrderId: "",
+    isLocationDetailPage: false,
+    source: "agol",
+    attributes: properties,
+  };
+}
 
 /**
  * Helper function to get current map bounds from MapRef

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -105,17 +105,6 @@ const AGOLMarker = ({
   onClick: (e: React.MouseEvent<HTMLDivElement>) => void;
 }) => <div onClick={onClick} className="agol-marker" />;
 
-/**
- * Helper function to log AGOL sign data to console
- */
-const logAGOLSignData = (sign: Sign) => {
-  console.group(`🟡 AGOL Sign Asset - ID: ${sign.spatialId}`);
-  console.info(
-    "📍 Location:",
-    `${sign.lat.toFixed(MAP_COORDINATE_PRECISION)}, ${sign.lng.toFixed(MAP_COORDINATE_PRECISION)}`
-  );
-  console.groupEnd();
-};
 
 /**
  * Takes array of Signs and returns array of map markers, one marker per sign
@@ -127,7 +116,7 @@ const logAGOLSignData = (sign: Sign) => {
  *
  * Interaction logic:
  * - Knack signs: Show popup with work order info when clicked
- * - AGOL signs: Log data to console when clicked (handled by AGOLMarker)
+ * - AGOL signs: Show popup with asset location ID and sign messages when clicked (handled by AGOLMarker)
  *
  * @param signs Array of Signs (can include both Knack and AGOL signs)
  * @param setPopupInfo State setter for popup display
@@ -166,7 +155,8 @@ export const useCreateSignPins = (
                 <AGOLMarker
                   onClick={(e) => {
                     e.stopPropagation();
-                    logAGOLSignData(sign);
+                    // Show popup for AGOL signs
+                    setPopupInfo(sign);
                   }}
                 />
               )}

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -181,7 +181,7 @@ export const useAGOLSignAssets = (
 
 /**
  * Converts a GeoJSON point feature from the AGOL layer (e.g. from map click) into a Sign
- * for use in the popup. Keeps conversion logic in one place for reviewers and reuse.
+ * for use in the popup.
  *
  * @param feature Clicked feature with Point geometry and AGOL properties (OBJECTID_1, etc.)
  * @returns Sign for popup, or null if feature is invalid


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/26317

<img width="1624" height="1056" alt="Screenshot 2026-01-20 at 10 36 18 AM" src="https://github.com/user-attachments/assets/289f91c8-7cbf-4115-9d41-12544782ff28" />

## Testing:
1. Go to this deploy preview: https://deploy-preview-338--nextjs-knack-signs-markings.netlify.app
2. Click on a yellow marker representing a sign asset, and verify the pop-up contains a Location ID and a list of 1 or more sign messages.
3. Click the map to close, open again, and click the `X` to close. Open again and click another asset marker to see the pop-up's data update, and that it moves the position of the pop-up, but doesn't close. Basically, just make sure the pop-up open and close behavior works as expected. 