### PR TITLE
Configures pop-ups for sign locations added to work order

### DIFF
--- a/knack/index.css
+++ b/knack/index.css
@@ -13,19 +13,56 @@ div.view_2565 .field_2403 {
 #lat-lon-form {
   color: white;
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 1);
-  margin-top: -145px;
-  padding-bottom: 40px;
+  margin-top: -88px;
+  padding-bottom: 16px;
+  position: relative;
+  z-index: 2;
 }
 
+/* Center the submit button horizontally at the bottom of the map */
+#lat-lon-form > form,
+#lat-lon-form > form > div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+
+/* Match the popup's Bootstrap btn-primary styling */
 #lat-lon-form button {
-  margin: -10px 0 0 10px;
-  color: #07467c !important;
-  background: white !important;
-  border: 3px solid #07467c;
-  font-size: 22px;
-  font-weight: bold;
-  height: 44px;
-  padding: 0 15px;
+  margin: 0 !important;
+  padding: 0.375rem 1rem !important;
+  color: #ffffff !important;
+  background-color: #0d6efd !important;
+  border: 1px solid #0d6efd !important;
+  border-radius: 0.25rem !important;
+  font-size: 1rem !important;
+  font-weight: 500 !important;
+  line-height: 1.5 !important;
+  height: auto !important;
+  min-width: 200px;
+  text-shadow: none;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition:
+    background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out;
+}
+
+#lat-lon-form button:hover {
+  background-color: #0b5ed7 !important;
+  border-color: #0a58ca !important;
+}
+
+#lat-lon-form button:focus,
+#lat-lon-form button:active {
+  background-color: #0a58ca !important;
+  border-color: #0a53be !important;
+  outline: none;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.5);
+}
+
+#lat-lon-form ul.kn-form-group {
+  width: 0;
 }
 
 .big-button-container {
@@ -95,9 +132,15 @@ a.small-button {
     width: 100%;
   }
 
-  /* Override width set for submit buttons to prevent overlaying map controls */
+  /* Centered, popup-style primary button on mobile — override the generic
+     submit button sizing above so it keeps the btn-primary look. */
   #lat-lon-form > form > div > button {
-    width: 50%;
+    width: auto !important;
+    min-width: 240px;
+    max-width: 80%;
+    height: auto !important;
+    font-size: 1.125rem !important;
+    padding: 0.5rem 1.25rem !important;
   }
 
   /* Increase font size of form field labels */
@@ -206,3 +249,48 @@ a.small-button {
   }
 }
 /* END #233 */
+
+#view_3207 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(2) > a{
+  color: white;
+  background-color: #3366cc;
+}
+
+#view_3207 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(3) > a{
+  color: white;
+  background-color: #ff0000;
+}
+#view_3207 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(4) > a{
+  color: white;
+  background-color: #008000;
+}
+#view_3207 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(5) > a{
+  color: white;
+  background-color: #ffa500;
+}
+#view_3207 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(6) > a{
+  color: white;
+  background-color: #000000;
+}
+
+#view_3217 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(2) > a{
+  color: white;
+  background-color: #3366cc;
+}
+
+#view_3217 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(3) > a{
+  color: white;
+  background-color: #ff0000;
+}
+#view_3217 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(4) > a{
+  color: white;
+  background-color: #008000;
+}
+#view_3217 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(5) > a{
+  color: white;
+  background-color: #ffa500;
+  
+}
+#view_3217 > div.kn-records-nav > div.js-filter-menu.tabs.is-toggle.is-flush > ul > li:nth-child(6) > a{
+  color: white;
+  background-color: #000000;
+ 

--- a/signs-work-order-map/app/globals.scss
+++ b/signs-work-order-map/app/globals.scss
@@ -126,6 +126,51 @@ a {
 }
 
 /**
+ * Work Order Sign Point
+ * Circle marker for Knack signs that mirrors the AGOL signs layer symbology.
+ * Includes an optional "NEW" label for freshly-created locations.
+ */
+.work-order-sign-point {
+  position: relative;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid #ffffff;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+
+  &--existing {
+    background: #ffc600; // yellow: existing sign
+  }
+
+  &--new {
+    background: #28a745; // green: newly created (no AGOL link)
+  }
+
+  &--detail {
+    background: #dc3545; // red: active location details page sign
+  }
+
+  &__label {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #28a745;
+    color: #ffffff;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 3px 6px;
+    border-radius: 3px;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  }
+}
+
+/**
  * Location Mode Toggle
  * Button group overlay for switching between Create Location and Select Existing modes
  */

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -38,6 +38,7 @@ import {
   useAGOLSignAssets,
   getMapBounds,
   agolFeatureToSign,
+  enrichKnackSignsWithAgol,
 } from "@/utils/mapUtils";
 import {
   DEFAULT_MAP_PARAMS,
@@ -156,7 +157,33 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
     () => signs.map((sign) => ({ ...sign, source: "knack" as const })),
     [signs]
   );
-  const signPins = useCreateSignPins(knackSigns, setPopupInfo);
+
+  // Merge AGOL attributes into co-located Knack signs and filter those
+  // AGOL features out of the layer so they don't render on top of Knack pins.
+  const { enrichedSigns, filteredAgolGeoJSON } = useMemo(() => {
+    if (!isZoomedInEnough || agolSignsGeoJSON.features.length === 0) {
+      return {
+        enrichedSigns: knackSigns,
+        filteredAgolGeoJSON: agolSignsGeoJSON,
+      };
+    }
+    const result = enrichKnackSignsWithAgol(
+      knackSigns,
+      agolSignsGeoJSON.features
+    );
+    const filtered =
+      result.matchedAgolObjectIds.size > 0
+        ? {
+            ...agolSignsGeoJSON,
+            features: agolSignsGeoJSON.features.filter(
+              (f) => !result.matchedAgolObjectIds.has(f.properties.OBJECTID_1)
+            ),
+          }
+        : agolSignsGeoJSON;
+    return { enrichedSigns: result.enrichedSigns, filteredAgolGeoJSON: filtered };
+  }, [knackSigns, agolSignsGeoJSON, isZoomedInEnough]);
+
+  const signPins = useCreateSignPins(enrichedSigns, setPopupInfo);
 
   const handleMouseEnter = useCallback(() => {
     if (mapRef.current) {
@@ -340,8 +367,8 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
 
       {signPins}
 
-      {isZoomedInEnough && agolSignsGeoJSON.features.length > 0 && (
-        <Source id={AGOL_SIGNS_SOURCE_ID} type="geojson" data={agolSignsGeoJSON}>
+      {isZoomedInEnough && filteredAgolGeoJSON.features.length > 0 && (
+        <Source id={AGOL_SIGNS_SOURCE_ID} type="geojson" data={filteredAgolGeoJSON}>
           <Layer {...AGOL_SIGNS_LAYER_STYLE} />
         </Source>
       )}

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -9,37 +9,55 @@ interface SignPopupProps {
   onSelectExistingLocation?: (sign: Sign) => void;
 }
 
+/**
+ * Parses the comma-separated SIGN_MESSAGES_AT_LOCATION value into a
+ * de-duped map of message → count.
+ */
+function parseSignMessages(raw: unknown): Map<string, number> | null {
+  if (raw == null) return null;
+  const list = String(raw)
+    .split(",")
+    .map((m) => m.trim())
+    .filter(Boolean);
+  if (list.length === 0) return null;
+  const counts = new Map<string, number>();
+  list.forEach((msg) => counts.set(msg, (counts.get(msg) ?? 0) + 1));
+  return counts;
+}
+
+function SignMessagesList({ raw }: { raw: unknown }) {
+  const counts = parseSignMessages(raw);
+  if (!counts) return null;
+  return (
+    <div className="mt-2 sign-popup-agol__scroll">
+      <ul className="list-group list-group-flush mb-0">
+        {Array.from(counts.entries()).map(([message, count]) => (
+          <li key={message} className="list-group-item px-0 py-3 fs-6">
+            {message}
+            {count > 1 && (
+              <span className="badge border text-dark bg-light ms-2">
+                x {count}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export default function SignPopup({
   popupInfo,
   setPopupInfo,
   locationMode,
   onSelectExistingLocation,
 }: SignPopupProps) {
-  // Check if this is an AGOL sign
   const isAGOLSign = popupInfo.source === "agol";
 
-  // Extract AGOL-specific fields
-  const assetLocationId = isAGOLSign
-    ? popupInfo.attributes?.ASSET_LOCATION_ID
-    : null;
-  const signMessagesAtLocation = isAGOLSign
-    ? popupInfo.attributes?.SIGN_MESSAGES_AT_LOCATION
-    : null;
-
-  // Split sign messages by comma and filter out empty strings
-  const signMessagesList = signMessagesAtLocation
-    ? String(signMessagesAtLocation)
-        .split(",")
-        .map((msg) => msg.trim())
-        .filter((msg) => msg.length > 0)
-    : [];
-
-  // Group identical sign messages and count occurrences:
-  const signMessageCounts = new Map<string, number>();
-  signMessagesList.forEach((message) => {
-    const current = signMessageCounts.get(message) ?? 0;
-    signMessageCounts.set(message, current + 1);
-  });
+  const assetLocationId = popupInfo.attributes?.ASSET_LOCATION_ID ?? null;
+  const hasLocationId =
+    assetLocationId != null && String(assetLocationId).trim() !== "";
+  const signMessages = popupInfo.attributes?.SIGN_MESSAGES_AT_LOCATION ?? null;
 
   return (
     <Popup
@@ -51,79 +69,62 @@ export default function SignPopup({
       maxWidth="min(92vw, 320px)"
       className="sign-popup"
     >
-      {isAGOLSign ? (
-        <div className="sign-popup-agol nav-tile card border-0 fs-6">
-          <div className="card-body p-2 d-flex flex-column sign-popup-agol__inner">
-            {assetLocationId != null && (
-              <div className="mb-0 mt-2 d-flex align-items-center flex-shrink-0">
-                <span className="fw-bold me-2">Location ID</span>
-                <span className="text-muted mb-0">
-                  {String(assetLocationId)}
-                </span>
-              </div>
-            )}
-            {signMessagesList.length > 0 && (
-              <div className="mt-2 sign-popup-agol__scroll">
-                <ul className="list-group list-group-flush mb-0">
-                  {Array.from(signMessageCounts.entries()).map(
-                    ([message, count]) => (
-                      <li
-                        key={message}
-                        className="list-group-item px-0 py-3 fs-6"
-                      >
-                        {message}
-                        {count > 1 && (
-                          <span className="badge border text-dark bg-light ms-2">
-                            x {count}
-                          </span>
-                        )}
-                      </li>
-                    )
-                  )}
-                </ul>
-              </div>
-            )}
-            {signMessagesList.length === 0 && assetLocationId == null && (
-              <div className="text-muted flex-shrink-0">
-                No additional information available
-              </div>
-            )}
-            {locationMode === "select_existing" &&
-              onSelectExistingLocation && (
-                <button
-                  type="button"
-                  className="btn btn-primary btn-sm w-100 mt-2 flex-shrink-0 sign-popup-agol__action"
-                  onClick={() => {
-                    onSelectExistingLocation(popupInfo);
-                    setPopupInfo(null);
-                  }}
-                >
-                  Add this Location
-                </button>
-              )}
-          </div>
-        </div>
-      ) : (
-        // Knack sign popup content (existing behavior)
-        <ul className="list-unstyled m-0">
-          {!popupInfo.isLocationDetailPage && (
-            <li>
+      <div className="sign-popup-agol nav-tile card border-0 fs-6">
+        <div className="card-body p-2 d-flex flex-column sign-popup-agol__inner">
+          {/* Location Detail Page link — Knack signs only */}
+          {!isAGOLSign && !popupInfo.isLocationDetailPage && (
+            <div className="mt-2 flex-shrink-0">
               <a
-                href={`${KNACK_APP_URL}#work-order-signs/view-work-orders-details-sign/${popupInfo?.workOrderId}/view-work-order-signs-location-details/${
-                  popupInfo.id
-                }`}
-                // ensure it doesn't open in the iframe
+                href={`${KNACK_APP_URL}#work-order-signs/view-work-orders-details-sign/${popupInfo.workOrderId}/view-work-order-signs-location-details/${popupInfo.id}`}
                 target="_top"
               >
                 Location Detail Page
               </a>
-            </li>
+            </div>
           )}
-          <li>Spatial ID: {popupInfo.spatialId}</li>
-          <li>Latitude: {popupInfo.lat}</li>
-          <li>Longitude: {popupInfo.lng}</li>
-        </ul>
-      )}
+
+          {/* Prefer Location ID; fall back to Spatial ID for Knack signs */}
+          {hasLocationId ? (
+            <div className="mb-0 mt-2 d-flex align-items-center flex-shrink-0">
+              <span className="fw-bold me-2">Location ID</span>
+              <span className="text-muted">{String(assetLocationId)}</span>
+            </div>
+          ) : (
+            !isAGOLSign && (
+              <div className="mb-0 mt-2 d-flex align-items-center flex-shrink-0">
+                <span className="fw-bold me-2">Spatial ID</span>
+                <span className="text-muted">{popupInfo.spatialId}</span>
+              </div>
+            )
+          )}
+
+          {/* Sign messages (AGOL-sourced, or merged into Knack pin) */}
+          <SignMessagesList raw={signMessages} />
+
+          {/* Empty state — only for pure AGOL signs with nothing to show */}
+          {isAGOLSign && !signMessages && !hasLocationId && (
+            <div className="text-muted flex-shrink-0">
+              No additional information available
+            </div>
+          )}
+
+          {/* "Add this Location" — only for AGOL signs in select_existing mode */}
+          {isAGOLSign &&
+            locationMode === "select_existing" &&
+            onSelectExistingLocation && (
+              <button
+                type="button"
+                className="btn btn-primary btn-sm w-100 mt-2 flex-shrink-0 sign-popup-agol__action"
+                onClick={() => {
+                  onSelectExistingLocation(popupInfo);
+                  setPopupInfo(null);
+                }}
+              >
+                Add this Location
+              </button>
+            )}
+        </div>
+      </div>
     </Popup>
   );
 }

--- a/signs-work-order-map/components/SignPopup.tsx
+++ b/signs-work-order-map/components/SignPopup.tsx
@@ -59,6 +59,19 @@ export default function SignPopup({
     assetLocationId != null && String(assetLocationId).trim() !== "";
   const signMessages = popupInfo.attributes?.SIGN_MESSAGES_AT_LOCATION ?? null;
 
+  // Knack signs can link to their location details page. We don't link when
+  // viewing the popup on the location details page itself, or for AGOL-only
+  // signs (no Knack record yet).
+  const locationDetailHref =
+    !isAGOLSign && !popupInfo.isLocationDetailPage
+      ? `${KNACK_APP_URL}#work-order-signs/view-work-orders-details-sign/${popupInfo.workOrderId}/view-work-order-signs-location-details/${popupInfo.id}`
+      : null;
+
+  const idLabel = hasLocationId ? "Location ID" : "Spatial ID";
+  const idValue = hasLocationId ? String(assetLocationId) : popupInfo.spatialId;
+  // AGOL-only signs: only show the ID if it's a Location ID (ASSET_LOCATION_ID)
+  const showIdRow = hasLocationId || !isAGOLSign;
+
   return (
     <Popup
       longitude={popupInfo.lng}
@@ -71,31 +84,18 @@ export default function SignPopup({
     >
       <div className="sign-popup-agol nav-tile card border-0 fs-6">
         <div className="card-body p-2 d-flex flex-column sign-popup-agol__inner">
-          {/* Location Detail Page link — Knack signs only */}
-          {!isAGOLSign && !popupInfo.isLocationDetailPage && (
-            <div className="mt-2 flex-shrink-0">
-              <a
-                href={`${KNACK_APP_URL}#work-order-signs/view-work-orders-details-sign/${popupInfo.workOrderId}/view-work-order-signs-location-details/${popupInfo.id}`}
-                target="_top"
-              >
-                Location Detail Page
-              </a>
-            </div>
-          )}
-
-          {/* Prefer Location ID; fall back to Spatial ID for Knack signs */}
-          {hasLocationId ? (
+          {/* ID row — Location ID preferred, Spatial ID fallback for Knack */}
+          {showIdRow && (
             <div className="mb-0 mt-2 d-flex align-items-center flex-shrink-0">
-              <span className="fw-bold me-2">Location ID</span>
-              <span className="text-muted">{String(assetLocationId)}</span>
+              <span className="fw-bold me-2">{idLabel}</span>
+              {locationDetailHref ? (
+                <a href={locationDetailHref} target="_top">
+                  {idValue}
+                </a>
+              ) : (
+                <span className="text-muted">{idValue}</span>
+              )}
             </div>
-          ) : (
-            !isAGOLSign && (
-              <div className="mb-0 mt-2 d-flex align-items-center flex-shrink-0">
-                <span className="fw-bold me-2">Spatial ID</span>
-                <span className="text-muted">{popupInfo.spatialId}</span>
-              </div>
-            )
           )}
 
           {/* Sign messages (AGOL-sourced, or merged into Knack pin) */}

--- a/signs-work-order-map/package-lock.json
+++ b/signs-work-order-map/package-lock.json
@@ -11,6 +11,7 @@
         "@mapbox/mapbox-gl-geocoder": "^5.0.3",
         "@netlify/plugin-nextjs": "^5.15.2",
         "@turf/bbox": "^7.2.0",
+        "@turf/distance": "^7.3.5",
         "@turf/helpers": "^7.2.0",
         "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
         "@types/mapbox-gl": "^3.4.1",
@@ -1337,12 +1338,41 @@
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/helpers": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
-      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+    "node_modules/@turf/distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
       "license": "MIT",
       "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },

--- a/signs-work-order-map/package.json
+++ b/signs-work-order-map/package.json
@@ -12,6 +12,7 @@
     "@mapbox/mapbox-gl-geocoder": "^5.0.3",
     "@netlify/plugin-nextjs": "^5.15.2",
     "@turf/bbox": "^7.2.0",
+    "@turf/distance": "^7.3.5",
     "@turf/helpers": "^7.2.0",
     "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
     "@types/mapbox-gl": "^3.4.1",

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -74,6 +74,9 @@ export interface KnackRecord {
   field_3425?: number;
   /** count of assets raw format*/
   field_3425_raw?: number;
+  /** AGOL asset location ID (set when location was added from an AGOL feature) */
+  field_4461?: string | number;
+  field_4461_raw?: string | number;
   /** knack record id */
   id: string;
 }

--- a/signs-work-order-map/types/map.ts
+++ b/signs-work-order-map/types/map.ts
@@ -27,6 +27,11 @@ export interface Sign {
   isLocationDetailPage: boolean;
   /** source of the sign data - 'knack' for existing data, 'agol' for ArcGIS Online */
   source?: "knack" | "agol";
+  /**
+   * True for Knack signs that were saved without an AGOL asset location id
+   * (i.e. created via the "Create Location" flow rather than selected from AGOL).
+   */
+  isNewLocation?: boolean;
   /** additional attributes from AGOL or other sources */
   attributes?: Record<string, unknown>;
 }

--- a/signs-work-order-map/utils/locationModeStorage.ts
+++ b/signs-work-order-map/utils/locationModeStorage.ts
@@ -10,14 +10,14 @@ function isLocationMode(value: string | null): value is LocationMode {
  * Persists Create Location vs Select Existing across iframe reloads (same tab / origin).
  */
 export function getStoredLocationMode(): LocationMode {
-  if (typeof window === "undefined") return "create";
+  if (typeof window === "undefined") return "select_existing";
   try {
     const raw = sessionStorage.getItem(STORAGE_KEY);
     if (isLocationMode(raw)) return raw;
   } catch {
     // private mode / quota
   }
-  return "create";
+  return "select_existing";
 }
 
 export function setStoredLocationMode(mode: LocationMode): void {

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -55,13 +55,18 @@ export const useFormatSignsRecords = (
     const signsArray: Sign[] = knackPayload.payload.records.reduce(
       (acc: Sign[], sign) => {
         if (sign.field_3300_raw.latitude && sign.field_3300_raw.longitude) {
-          const newSign = {
+          const assetLocationId = sign.field_4461_raw ?? sign.field_4461;
+          const newSign: Sign = {
             id: sign.id,
             lat: sign.field_3300_raw.latitude,
             lng: sign.field_3300_raw.longitude,
             spatialId: sign.field_3297,
             workOrderId: knackPayload.payload.workOrderId,
             isLocationDetailPage: sign.id === locationId,
+            ...(assetLocationId != null &&
+            String(assetLocationId).trim() !== ""
+              ? { attributes: { ASSET_LOCATION_ID: assetLocationId } }
+              : {}),
           };
           acc.push(newSign);
         }
@@ -217,6 +222,79 @@ export function agolFeatureToSign(feature: unknown): Sign | null {
     source: "agol",
     attributes: properties,
   };
+}
+
+const COLOCATION_THRESHOLD_METERS = 5;
+
+function haversineDistanceMeters(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number
+): number {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * For each Knack sign, find the nearest co-located AGOL feature (within ~5 m)
+ * and merge its properties into the sign's `attributes`.
+ *
+ * Returns the (possibly-enriched) signs and the set of AGOL `OBJECTID_1` values
+ * that were matched, so the caller can filter them out of the AGOL layer.
+ */
+export function enrichKnackSignsWithAgol(
+  knackSigns: Sign[],
+  agolFeatures: ReadonlyArray<{
+    properties: Record<string, unknown>;
+    geometry: { type: string; coordinates: number[] };
+  }>
+): {
+  enrichedSigns: Sign[];
+  matchedAgolObjectIds: Set<unknown>;
+} {
+  const matchedAgolObjectIds = new Set<unknown>();
+
+  const enrichedSigns = knackSigns.map((sign) => {
+    let bestMatch: (typeof agolFeatures)[number] | null = null;
+    let bestDist = Infinity;
+
+    for (const feature of agolFeatures) {
+      if (
+        feature.geometry.type !== "Point" ||
+        feature.geometry.coordinates.length < 2
+      )
+        continue;
+      const [fLng, fLat] = feature.geometry.coordinates;
+      const dist = haversineDistanceMeters(sign.lat, sign.lng, fLat, fLng);
+      if (dist <= COLOCATION_THRESHOLD_METERS && dist < bestDist) {
+        bestDist = dist;
+        bestMatch = feature;
+      }
+    }
+
+    if (!bestMatch) return sign;
+
+    matchedAgolObjectIds.add(bestMatch.properties.OBJECTID_1);
+
+    return {
+      ...sign,
+      attributes: {
+        ...bestMatch.properties,
+        ...(sign.attributes ?? {}),
+      },
+    };
+  });
+
+  return { enrichedSigns, matchedAgolObjectIds };
 }
 
 /**

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import bbox from "@turf/bbox";
+import distance from "@turf/distance";
 import { lineString } from "@turf/helpers";
 import { LngLatBoundsLike } from "mapbox-gl";
 import { Marker } from "react-map-gl/mapbox";
@@ -247,30 +248,13 @@ export function agolFeatureToSign(feature: unknown): Sign | null {
 
 const COLOCATION_THRESHOLD_METERS = 5;
 
-function haversineDistanceMeters(
-  lat1: number,
-  lng1: number,
-  lat2: number,
-  lng2: number
-): number {
-  const R = 6371000;
-  const toRad = (d: number) => (d * Math.PI) / 180;
-  const dLat = toRad(lat2 - lat1);
-  const dLng = toRad(lng2 - lng1);
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) *
-      Math.cos(toRad(lat2)) *
-      Math.sin(dLng / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
 /**
  * For each Knack sign, find the nearest co-located AGOL feature (within ~5 m)
  * and merge its properties into the sign's `attributes`.
  *
- * Returns the (possibly-enriched) signs and the set of AGOL `OBJECTID_1` values
- * that were matched, so the caller can filter them out of the AGOL layer.
+ * Distance is computed via @turf/distance. Returns
+ * the (possibly-enriched) signs and the set of AGOL `OBJECTID_1` values that
+ * were matched, so the caller can filter them out of the AGOL layer.
  */
 export function enrichKnackSignsWithAgol(
   knackSigns: Sign[],
@@ -285,6 +269,7 @@ export function enrichKnackSignsWithAgol(
   const matchedAgolObjectIds = new Set<unknown>();
 
   const enrichedSigns = knackSigns.map((sign) => {
+    const signCoord: [number, number] = [sign.lng, sign.lat];
     let bestMatch: (typeof agolFeatures)[number] | null = null;
     let bestDist = Infinity;
 
@@ -294,8 +279,8 @@ export function enrichKnackSignsWithAgol(
         feature.geometry.coordinates.length < 2
       )
         continue;
-      const [fLng, fLat] = feature.geometry.coordinates;
-      const dist = haversineDistanceMeters(sign.lat, sign.lng, fLat, fLng);
+      const featureCoord = feature.geometry.coordinates as [number, number];
+      const dist = distance(signCoord, featureCoord, { units: "meters" });
       if (dist <= COLOCATION_THRESHOLD_METERS && dist < bestDist) {
         bestDist = dist;
         bestMatch = feature;

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -56,6 +56,8 @@ export const useFormatSignsRecords = (
       (acc: Sign[], sign) => {
         if (sign.field_3300_raw.latitude && sign.field_3300_raw.longitude) {
           const assetLocationId = sign.field_4461_raw ?? sign.field_4461;
+          const hasAssetLocationId =
+            assetLocationId != null && String(assetLocationId).trim() !== "";
           const newSign: Sign = {
             id: sign.id,
             lat: sign.field_3300_raw.latitude,
@@ -63,8 +65,8 @@ export const useFormatSignsRecords = (
             spatialId: sign.field_3297,
             workOrderId: knackPayload.payload.workOrderId,
             isLocationDetailPage: sign.id === locationId,
-            ...(assetLocationId != null &&
-            String(assetLocationId).trim() !== ""
+            isNewLocation: !hasAssetLocationId,
+            ...(hasAssetLocationId
               ? { attributes: { ASSET_LOCATION_ID: assetLocationId } }
               : {}),
           };
@@ -101,9 +103,10 @@ export const useFormatLocation = (
  * Takes array of Knack Signs and returns array of map markers.
  * AGOL signs are rendered via a GeoJSON Layer in Map.tsx for performance.
  *
- * Marker color logic:
- * - Red: Location detail page sign (isLocationDetailPage = true)
- * - Default blue: Knack work order signs
+ * Point styling:
+ * - Red dot: Location detail page sign (isLocationDetailPage = true)
+ * - Yellow dot: Existing Knack work order sign
+ * - Green dot with "NEW" label: Sign created via "Create Location" (no AGOL link)
  *
  * @param signs Array of Knack Signs
  * @param setPopupInfo State setter for popup display
@@ -115,22 +118,40 @@ export const useCreateSignPins = (
 ) =>
   useMemo(
     () =>
-      signs.map(
-        (sign: Sign) =>
-          sign.lat &&
-          sign.lng && (
-            <Marker
-              key={`marker-${sign.id}`}
-              longitude={sign.lng}
-              latitude={sign.lat}
-              color={sign.isLocationDetailPage ? "red" : "#FFC600"}
-              onClick={(e) => {
-                e.originalEvent.stopPropagation();
-                setPopupInfo(sign);
-              }}
-            />
-          )
-      ),
+      signs.map((sign: Sign) => {
+        if (!sign.lat || !sign.lng) return null;
+        const modifierClass = sign.isLocationDetailPage
+          ? "work-order-sign-point--detail"
+          : sign.isNewLocation
+            ? "work-order-sign-point--new"
+            : "work-order-sign-point--existing";
+        return (
+          <Marker
+            key={`marker-${sign.id}`}
+            longitude={sign.lng}
+            latitude={sign.lat}
+            anchor="center"
+            onClick={(e) => {
+              e.originalEvent.stopPropagation();
+              setPopupInfo(sign);
+            }}
+          >
+            <div
+              className={`work-order-sign-point ${modifierClass}`}
+              role="button"
+              aria-label={
+                sign.isNewLocation
+                  ? "New work order sign location"
+                  : "Work order sign location"
+              }
+            >
+              {sign.isNewLocation && (
+                <span className="work-order-sign-point__label">NEW</span>
+              )}
+            </div>
+          </Marker>
+        );
+      }),
     [signs, setPopupInfo]
   );
 


### PR DESCRIPTION
## Associated issue
Closes https://github.com/cityofaustin/atd-data-tech/issues/26881

## Summary

Two related pieces of work shipped together on this branch:

### 1. Pop-up enhancements for sign locations added to a work order
- Popups now prefer **Location ID** (from AGOL `ASSET_LOCATION_ID` / Knack `field_4461`) and fall back to **Spatial ID** only when no Location ID is present.
- Lat/lng is no longer shown in the popup.
- When a Knack sign-location pin shares a lat/lng with an AGOL sign (within ~5 m), the AGOL marker is hidden and its attributes (including sign messages) are merged into the Knack pin's popup.
- The ID row in the popup is now a link that opens the Location Details page in Knack.

### 2. Symbology + default mode + "Add Location" button styling
- Knack sign locations now render as circular points (not pins) with state-based styling:
  - **Yellow** — existing Knack sign location
  - **Green with a "NEW" label** — newly-created location (no AGOL `ASSET_LOCATION_ID`)
  - **Red** — the location currently being viewed on a Location Details page
- Map defaults to **Select Existing** mode on first load; user's last choice is still persisted in `sessionStorage`.
- The "Add Location" button in Create Location mode is restyled to match the popup's Bootstrap `btn-primary` and is centered at the bottom of the map.

<img width="1734" height="553" alt="Screenshot 2026-04-22 at 4 24 38 PM" src="https://github.com/user-attachments/assets/35b0ccaf-f51e-495a-ad85-ca47eb6a7947" />

<img width="327" height="299" alt="Screenshot 2026-04-22 at 4 24 59 PM" src="https://github.com/user-attachments/assets/a3e630bc-30a3-4843-a7d3-3e36b47e5777" />


## Testing

Use the [test Knack app `test-30-may-2024-signs-and-markings-operations`](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/664b674284dc300029e338aa/) and GIS QA credentials (from 1Password).

**Steps to test:**

### 1. Default mode is "Select Existing"
1. If necessary, clear `sessionStorage` for the Knack app origin (DevTools > Application > Storage > Clear site data), then load the Add Sign Location view on an existing work order.
1. Expected: The **Select Existing** toggle is active by default (not Create Location).
1. Switch to **Create Location**, reload the page.
1. Expected: The map restores **Create Location** — the last-used mode is still persisted across reloads.

### 2. Pop-ups prefer Location ID and link to details & No lat/lng in popups
1. In **Select Existing** mode, click an AGOL sign that is **not** already added to the work order.
1. Expected popup shows: sign message(s), no lat/lng row, no Spatial ID.
1. Add the location to the work order, then click the newly-created pin.
1. Expected: The pin is **yellow** (indicating it was created from an existing sign location). Also, the popup shows **Location ID**, and the ID is a link to that location's details page.
1. From **Create Location** mode, drop a new pin by dragging the red pin in place and clicking "Add Location" button.
1. Expected: The new pin is **green** (new), popup shows **Spatial ID** (not Location ID since it creates a new value instead of inheriting one from AGOL), and the ID links to the location's details page.
1. Click any sign popup (AGOL-only, existing Knack, newly-created Knack).
1. Expected: **No** `Lat` / `Lng` rows in any popup variant.

### 3. Co-located AGOL + Knack sign de-dup
1. Find a work order with at least one Knack sign location that was originally added from AGOL (ex: [link this one](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/664b85725d3e620028be63c0/)).
1. Load the map and zoom in until AGOL features appear.
1. Expected: At that Knack pin's location, **only the yellow Knack point is visible** — the AGOL marker at the same lat/lng should be hidden.
1. Click the Knack point. Expected: The popup shows the Location ID and the **sign messages merged in from AGOL** (proves the AGOL attributes were merged rather than dropped).
1. Zoom out past the AGOL display threshold and back in. Expected: Blue dots disappear outside zoom threshold, yellow dots stay visible.
1. From "Select Existing" mode, click a blue dot to open the popup and "Add this Location". Expected: When the map reloads, only a yellow dot appears in the place of the blue dot that was there.

### 4. Symbology
1. On a work order with mixed signs, visually confirm:
    - Existing Knack locations → **yellow** circle, no label
    - Newly-created (from "Create Location" mode) → **green** circle with **NEW** label
    - If you navigate into a Location Details page, the sign for the current location renders as a **red** circle.

### 5. "Add Location" button update in "Create Location" mode
1. Switch to **Create Location** mode on a work order map.
1. Expected: The **Add Location** button is styled like the blue popup primary button (matching `btn-primary`), and is **centered at the bottom** of the map, not tucked into the form layout.
1. Click the button. Expected: A new location is created at the center of the map and handed off to Knack as before.