### PR TITLE
Match by location instead of proximity

### DIFF
--- a/signs-work-order-map/app/globals.scss
+++ b/signs-work-order-map/app/globals.scss
@@ -129,13 +129,15 @@ a {
  * Work Order Sign Point
  * Circle marker for Knack signs that mirrors the AGOL signs layer symbology.
  * Includes an optional "NEW" label for freshly-created locations.
+ * Width/height/borderWidth are set inline from getSignPointStyleAtZoom() in config/map.ts
+ * so pins stay the same size as cyan AGOL dots at the current zoom (iPad touch tuning).
  */
 .work-order-sign-point {
   position: relative;
-  width: 16px;
-  height: 16px;
   border-radius: 50%;
-  border: 2px solid #ffffff;
+  border-style: solid;
+  border-color: #ffffff;
+  box-sizing: border-box;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
   cursor: pointer;
 

--- a/signs-work-order-map/components/Map.tsx
+++ b/signs-work-order-map/components/Map.tsx
@@ -183,7 +183,7 @@ export default function Map({ signs, messageType, editLocation }: MapProps) {
     return { enrichedSigns: result.enrichedSigns, filteredAgolGeoJSON: filtered };
   }, [knackSigns, agolSignsGeoJSON, isZoomedInEnough]);
 
-  const signPins = useCreateSignPins(enrichedSigns, setPopupInfo);
+  const signPins = useCreateSignPins(enrichedSigns, setPopupInfo, zoom);
 
   const handleMouseEnter = useCallback(() => {
     if (mapRef.current) {

--- a/signs-work-order-map/config/map.ts
+++ b/signs-work-order-map/config/map.ts
@@ -31,13 +31,52 @@ export const SIGN_LOCATION_BOUNDS_FIT_OPTIONS = {
  */
 export const AGOL_SIGNS_MIN_ZOOM = 15.5;
 
+/** Touch-friendly sign size; stops match AGOL_SIGNS_LAYER_STYLE below */
+const SIGN_POINT_SIZE = {
+  zMin: 15,
+  zMax: 20,
+  radius: [6, 18],
+  stroke: [1, 4],
+} as const;
+
+/** Size between "zoomed out" and "zoomed in" values for the current map zoom */
+function scaleSignPointByZoom(
+  zoom: number,
+  sizeWhenZoomedOut: number,
+  sizeWhenZoomedIn: number
+): number {
+  const { zMin, zMax } = SIGN_POINT_SIZE;
+  const blend = Math.max(0, Math.min(1, (zoom - zMin) / (zMax - zMin)));
+  return sizeWhenZoomedOut + (sizeWhenZoomedIn - sizeWhenZoomedOut) * blend;
+}
+
+/** Knack pin dimensions at zoom — kept in sync with cyan AGOL circles */
+export function getSignPointStyleAtZoom(zoom: number) {
+  const borderWidth = Math.round(
+    scaleSignPointByZoom(
+      zoom,
+      SIGN_POINT_SIZE.stroke[0],
+      SIGN_POINT_SIZE.stroke[1]
+    )
+  );
+  const radius = scaleSignPointByZoom(
+    zoom,
+    SIGN_POINT_SIZE.radius[0],
+    SIGN_POINT_SIZE.radius[1]
+  );
+  return {
+    diameter: Math.round(radius * 2 + borderWidth * 2),
+    borderWidth,
+  };
+}
+
 /** Mapbox source and layer ids for the AGOL signs GeoJSON layer */
 export const AGOL_SIGNS_SOURCE_ID = "agol-signs";
 export const AGOL_SIGNS_LAYER_ID = "agol-signs-layer";
 
 /**
  * Mapbox circle layer style for AGOL sign points.
- * Single WebGL layer for performance; radius tuned for touch (e.g. iPad).
+ * Single WebGL layer for performance; radius grows with zoom for touch targets.
  */
 export const AGOL_SIGNS_LAYER_STYLE: CircleLayerSpecification = {
   id: AGOL_SIGNS_LAYER_ID,
@@ -50,20 +89,22 @@ export const AGOL_SIGNS_LAYER_STYLE: CircleLayerSpecification = {
       "interpolate",
       ["linear"],
       ["zoom"],
-      // Just above min zoom for signs
-      15,
-      6,
-      // Very close in
-      20,
-      18,
+      SIGN_POINT_SIZE.zMin,
+      SIGN_POINT_SIZE.radius[0],
+      SIGN_POINT_SIZE.zMax,
+      SIGN_POINT_SIZE.radius[1],
     ],
-    // Base fill color; tuned for contrast over aerial imagery.
     "circle-color": "#00FFFF",
-    // White stroke to improve contrast between overlapping points
-    // and against dark / light aerial backgrounds.
     "circle-stroke-color": "#FFFFFF",
-    // Thicker stroke at higher zoom to match larger circles
-    "circle-stroke-width": ["interpolate", ["linear"], ["zoom"], 15, 1, 20, 4],
+    "circle-stroke-width": [
+      "interpolate",
+      ["linear"],
+      ["zoom"],
+      SIGN_POINT_SIZE.zMin,
+      SIGN_POINT_SIZE.stroke[0],
+      SIGN_POINT_SIZE.zMax,
+      SIGN_POINT_SIZE.stroke[1],
+    ],
   },
 };
 

--- a/signs-work-order-map/utils/iFrameMessenger.tsx
+++ b/signs-work-order-map/utils/iFrameMessenger.tsx
@@ -2,22 +2,56 @@
 import { useEffect, useState } from "react";
 import { KnackToIFrameMessage, LatLon, LocationMode } from "@/types/map";
 
+const KNACK_TO_IFRAME_MESSAGE_TYPES = [
+  "LOAD_WORK_ORDER_LOCATION_DETAILS_PAGE",
+  "LOAD_WORK_ORDER_DETAILS_PAGE",
+  "OPEN_LOCATION_EDITOR",
+] as const;
+
+function parseMessageEventData(data: unknown): unknown {
+  if (data == null) return null;
+  if (typeof data === "string") {
+    try {
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof data === "object") return data;
+  return null;
+}
+
+function isKnackToIFrameMessage(value: unknown): value is KnackToIFrameMessage {
+  if (!value || typeof value !== "object" || !("message" in value)) {
+    return false;
+  }
+  const { message } = value as { message: unknown };
+  return (
+    typeof message === "string" &&
+    (KNACK_TO_IFRAME_MESSAGE_TYPES as readonly string[]).includes(message)
+  );
+}
+
 export function useIFrameMessenger() {
   const [message, setMessage] = useState<KnackToIFrameMessage | null>(null);
 
   useEffect(() => {
-    const consoleMessage = (event: MessageEvent) => {
+    const onMessage = (event: MessageEvent) => {
       if (event.origin !== "https://atd.knack.com") {
         return;
       }
 
-      const data: KnackToIFrameMessage = JSON.parse(event?.data);
-      setMessage(data);
+      const parsed = parseMessageEventData(event.data);
+      if (!isKnackToIFrameMessage(parsed)) {
+        return;
+      }
+
+      setMessage(parsed);
     };
-    window.addEventListener("message", consoleMessage);
+    window.addEventListener("message", onMessage);
 
     return () => {
-      window.removeEventListener("message", consoleMessage);
+      window.removeEventListener("message", onMessage);
     };
   }, []);
 

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import bbox from "@turf/bbox";
-import distance from "@turf/distance";
 import { lineString } from "@turf/helpers";
 import { LngLatBoundsLike } from "mapbox-gl";
 import { Marker } from "react-map-gl/mapbox";
@@ -47,13 +46,25 @@ export const useFormatSignsRecords = (
       return [];
     }
 
+    if (
+      knackPayload.message !== "LOAD_WORK_ORDER_DETAILS_PAGE" &&
+      knackPayload.message !== "LOAD_WORK_ORDER_LOCATION_DETAILS_PAGE"
+    ) {
+      return [];
+    }
+
+    const records = knackPayload.payload?.records;
+    if (!Array.isArray(records)) {
+      return [];
+    }
+
     const locationId =
       knackPayload.message === "LOAD_WORK_ORDER_LOCATION_DETAILS_PAGE"
-        ? knackPayload?.payload?.locationRecordId
+        ? knackPayload.payload.locationRecordId
         : null;
 
     // Knack will save undefined latitudes and longitudes, this filters those out.
-    const signsArray: Sign[] = knackPayload.payload.records.reduce(
+    const signsArray: Sign[] = records.reduce(
       (acc: Sign[], sign) => {
         if (sign.field_3300_raw.latitude && sign.field_3300_raw.longitude) {
           const assetLocationId = sign.field_4461_raw ?? sign.field_4461;
@@ -246,47 +257,73 @@ export function agolFeatureToSign(feature: unknown): Sign | null {
   };
 }
 
-const COLOCATION_THRESHOLD_METERS = 5;
+type AgolFeature = {
+  properties: Record<string, unknown>;
+  geometry: { type: string; coordinates: number[] };
+};
+
+function normalizeAssetLocationId(id: unknown): string | null {
+  if (id == null) return null;
+  const normalized = String(id).trim();
+  return normalized === "" ? null : normalized;
+}
+
+function isAgolPointFeature(
+  feature: AgolFeature
+): feature is AgolFeature & {
+  geometry: { type: "Point"; coordinates: [number, number] };
+} {
+  return (
+    feature.geometry.type === "Point" &&
+    feature.geometry.coordinates.length >= 2
+  );
+}
+
+function buildAgolIndexes(agolFeatures: ReadonlyArray<AgolFeature>) {
+  const byLocationId = new Map<string, AgolFeature>();
+
+  for (const feature of agolFeatures) {
+    if (!isAgolPointFeature(feature)) continue;
+
+    const locationId = normalizeAssetLocationId(
+      feature.properties.ASSET_LOCATION_ID
+    );
+    if (locationId && !byLocationId.has(locationId)) {
+      byLocationId.set(locationId, feature);
+    }
+  }
+
+  return { byLocationId };
+}
 
 /**
- * For each Knack sign, find the nearest co-located AGOL feature (within ~5 m)
- * and merge its properties into the sign's `attributes`.
+ * For each Knack sign, find the corresponding AGOL feature and merge its
+ * properties into the sign's `attributes`.
  *
- * Distance is computed via @turf/distance. Returns
- * the (possibly-enriched) signs and the set of AGOL `OBJECTID_1` values that
- * were matched, so the caller can filter them out of the AGOL layer.
+ * Matched on ASSET_LOCATION_ID (Knack field_4461 / AGOL ASSET_LOCATION_ID).
+ * Signs without a location ID are not merged (e.g. Create Location flow).
+ *
+ * Returns the enriched signs and matched AGOL `OBJECTID_1` values so the caller
+ * can filter them out of the AGOL layer.
  */
 export function enrichKnackSignsWithAgol(
   knackSigns: Sign[],
-  agolFeatures: ReadonlyArray<{
-    properties: Record<string, unknown>;
-    geometry: { type: string; coordinates: number[] };
-  }>
+  agolFeatures: ReadonlyArray<AgolFeature>
 ): {
   enrichedSigns: Sign[];
   matchedAgolObjectIds: Set<unknown>;
 } {
   const matchedAgolObjectIds = new Set<unknown>();
+  const { byLocationId } = buildAgolIndexes(agolFeatures);
 
   const enrichedSigns = knackSigns.map((sign) => {
-    const signCoord: [number, number] = [sign.lng, sign.lat];
-    let bestMatch: (typeof agolFeatures)[number] | null = null;
-    let bestDist = Infinity;
+    const signLocationId = normalizeAssetLocationId(
+      sign.attributes?.ASSET_LOCATION_ID
+    );
 
-    for (const feature of agolFeatures) {
-      if (
-        feature.geometry.type !== "Point" ||
-        feature.geometry.coordinates.length < 2
-      )
-        continue;
-      const featureCoord = feature.geometry.coordinates as [number, number];
-      const dist = distance(signCoord, featureCoord, { units: "meters" });
-      if (dist <= COLOCATION_THRESHOLD_METERS && dist < bestDist) {
-        bestDist = dist;
-        bestMatch = feature;
-      }
-    }
+    if (!signLocationId) return sign;
 
+    const bestMatch = byLocationId.get(signLocationId);
     if (!bestMatch) return sign;
 
     matchedAgolObjectIds.add(bestMatch.properties.OBJECTID_1);

--- a/signs-work-order-map/utils/mapUtils.tsx
+++ b/signs-work-order-map/utils/mapUtils.tsx
@@ -4,7 +4,10 @@ import { lineString } from "@turf/helpers";
 import { LngLatBoundsLike } from "mapbox-gl";
 import { Marker } from "react-map-gl/mapbox";
 import { Sign, KnackToIFrameMessage, LatLon } from "@/types/map";
-import { MAP_COORDINATE_PRECISION } from "@/config/map";
+import {
+  MAP_COORDINATE_PRECISION,
+  getSignPointStyleAtZoom,
+} from "@/config/map";
 import { useSignAssetsFeatureService } from "@/utils/agol";
 
 /**
@@ -126,11 +129,14 @@ export const useFormatLocation = (
  */
 export const useCreateSignPins = (
   signs: Sign[],
-  setPopupInfo: React.Dispatch<React.SetStateAction<Sign | null>>
+  setPopupInfo: React.Dispatch<React.SetStateAction<Sign | null>>,
+  zoom: number
 ) =>
-  useMemo(
-    () =>
-      signs.map((sign: Sign) => {
+  useMemo(() => {
+    const { diameter: pointSizePx, borderWidth: pointBorderPx } =
+      getSignPointStyleAtZoom(zoom);
+
+    return signs.map((sign: Sign) => {
         if (!sign.lat || !sign.lng) return null;
         const modifierClass = sign.isLocationDetailPage
           ? "work-order-sign-point--detail"
@@ -150,6 +156,11 @@ export const useCreateSignPins = (
           >
             <div
               className={`work-order-sign-point ${modifierClass}`}
+              style={{
+                width: pointSizePx,
+                height: pointSizePx,
+                borderWidth: pointBorderPx,
+              }}
               role="button"
               aria-label={
                 sign.isNewLocation
@@ -163,9 +174,8 @@ export const useCreateSignPins = (
             </div>
           </Marker>
         );
-      }),
-    [signs, setPopupInfo]
-  );
+      });
+  }, [signs, setPopupInfo, zoom]);
 
 /**
  * @returns If geolocation permissions are on, return LatLon


### PR DESCRIPTION
## Associated issue

Addresses this feedback from John:
https://github.com/cityofaustin/atd-knack-signs-markings/pull/343#discussion_r3220790892

## Summary

This PR uses a better approach for sign deduplication and fixes a bug in the Select Existing flow.

**Match Knack and AGOL signs by Location ID (not distance)**
`enrichKnackSignsWithAgol` no longer pairs Knack work-order pins with nearby AGOL features using a 5 meter proximity threshold. It now joins on `ASSET_LOCATION_ID` (Knack field_4461 / AGOL ASSET_LOCATION_ID). That avoids incorrectly merging or hiding the wrong AGOL marker when many signs are close together.

**iframe messaging bug fix**
`useIFrameMessenger` only accepts inbound Knack message types and safely parses `event.data`. Outbound messages such as `EXISTING_LOCATION_SELECTED` and `LOCATION_MODE_CHANGE` are ignored so they cannot overwrite the last valid work-order payload. `useFormatSignsRecords` guards against missing `payload.records` so the map does not crash if an unexpected message shape is received.

## Testing

Use the [test Knack app `test-30-may-2024-signs-and-markings-operations`](https://atd.knack.com/test-30-may-2024-signs-and-markings-operations#work-order-signs/view-work-orders-details-sign/664b674284dc300029e338aa/) and "Test GIS - Signs & Markings Tracker" credentials (from 1Password).

**Steps to test:**

1. Open a work order detail page and toggle to "Select Existing" in the map view
1. Zoom in until blue AGOL dots appear.
1. Click a blue dot to open the popup, click "Add this Location".
1. Map data will refresh, zoom back in to where you were (I know this part is annoying, trying to address it in #344 
Expected: No runtime error; form submits; map stays usable until Knack sends updated data; new yellow pin appears after reload/data push and appears to merge data where the blue dot was.


